### PR TITLE
Фикс тайлов-решёток

### DIFF
--- a/Resources/Prototypes/Imperial/Tiles/imperial_floors.yml
+++ b/Resources/Prototypes/Imperial/Tiles/imperial_floors.yml
@@ -5,6 +5,7 @@
   sprite: /Textures/Imperial/Tiles/LatticeSmall1.png
   baseTurf: Space
   isSubfloor: true
+  deconstructTools: [ Cutting ]
   canWirecutter: true
   weather: true
   footstepSounds:
@@ -21,6 +22,7 @@
   sprite: /Textures/Imperial/Tiles/LatticeSmall2.png
   baseTurf: Space
   isSubfloor: true
+  deconstructTools: [ Cutting ]
   canWirecutter: true
   weather: true
   footstepSounds:
@@ -37,6 +39,7 @@
   sprite: /Textures/Imperial/Tiles/LatticeSmall3.png
   baseTurf: Space
   isSubfloor: true
+  deconstructTools: [ Cutting ]
   canWirecutter: true
   weather: true
   footstepSounds:
@@ -53,6 +56,7 @@
   sprite: /Textures/Imperial/Tiles/LatticeSmall4.png
   baseTurf: Space
   isSubfloor: true
+  deconstructTools: [ Cutting ]
   canWirecutter: true
   weather: true
   footstepSounds:
@@ -69,6 +73,7 @@
   sprite: /Textures/Imperial/Tiles/LatticeCorner1.png
   baseTurf: Space
   isSubfloor: true
+  deconstructTools: [ Cutting ]
   canWirecutter: true
   weather: true
   footstepSounds:
@@ -85,6 +90,7 @@
   sprite: /Textures/Imperial/Tiles/LatticeCorner2.png
   baseTurf: Space
   isSubfloor: true
+  deconstructTools: [ Cutting ]
   canWirecutter: true
   weather: true
   footstepSounds:
@@ -101,6 +107,7 @@
   sprite: /Textures/Imperial/Tiles/LatticeCorner3.png
   baseTurf: Space
   isSubfloor: true
+  deconstructTools: [ Cutting ]
   canWirecutter: true
   weather: true
   footstepSounds:
@@ -117,6 +124,7 @@
   sprite: /Textures/Imperial/Tiles/LatticeCorner4.png
   baseTurf: Space
   isSubfloor: true
+  deconstructTools: [ Cutting ]
   canWirecutter: true
   weather: true
   footstepSounds:


### PR DESCRIPTION
На данный момент, диагональные и половинчатые тайлы-решётки невозможно убрать кусачками, хотя полный тайл-решётку таким образом убрать можно. Эта ПРка фиксит этот недочёт.