### PR TITLE
Самозарядка энергодробовика

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -740,15 +740,18 @@
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: ProjectileBatteryAmmoProvider
     proto: BulletLaserSpread
-    fireCost: 100
+    fireCost: 200
   - type: BatteryWeaponFireModes
     fireModes:
     - proto: BulletLaserSpread
-      fireCost: 100
+      fireCost: 200
     - proto: BulletLaserSpreadNarrow
-      fireCost: 100
+      fireCost: 200
     - proto: BulletDisablerSmgSpread
       fireCost: 100
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 10
   - type: Item
     size: Large
     shape:


### PR DESCRIPTION
## About the PR
Добавлена самозарядка энергодробовику, взамен количество летальных выстрелов снижено в два раза (8->4)

## Why / Balance
Посмотрел по дискордам других серверов. Как пишут — лежит в шкафу и ждет антага с целью на кражу, так как лазер не проходит через стекла (поэтому легче взять какую-нибудь лазерку, ведь она тоже требует зарядки, но выстрелов больше)
Станер используют для стамина крита на дальних дистанциях, на ближних по сути должен быть дробовик, но людям выгоднее станбатоны использовать


