### PR TITLE
Фикс рефлекта при держании отражающего бронежилета

### DIFF
--- a/Content.Shared/Weapons/Reflect/ReflectComponent.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectComponent.cs
@@ -1,5 +1,6 @@
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Content.Shared.Inventory;
 
 namespace Content.Shared.Weapons.Reflect;
 
@@ -15,6 +16,29 @@ public sealed partial class ReflectComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("reflects")]
     public ReflectType Reflects = ReflectType.Energy | ReflectType.NonEnergy;
+
+    /// Фикс системы, чтобы рефлект отражающего бронежилета работал только тогда, когда он надет в слот взят из ПР Wizard #31902. Автор: BIGZi0348 START Imperial Space
+    
+    /// <summary> 
+    /// Select in which inventory slots it will reflect. 
+    /// By default, it will reflect in any inventory position, except pockets.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField]
+    public SlotFlags SlotFlags = SlotFlags.WITHOUT_POCKET;
+
+    /// <summary>
+    /// Is it allowed to reflect while being in hands.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public bool ReflectingInHands = true;
+
+    /// <summary>
+    /// Can only reflect when placed correctly.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public bool InRightPlace = true;
+
+    /// Фикс системы, чтобы рефлект отражающего бронежилета работал только тогда, когда он надет в слот взят из ПР Wizard #31902. Автор: BIGZi0348  END Imperial Space
 
     /// <summary>
     /// Probability for a projectile to be reflected.

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -96,6 +96,7 @@ public sealed class ReflectSystem : EntitySystem
     {
         if (!Resolve(reflector, ref reflect, false) ||
             !_toggle.IsActivated(reflector) ||
+            !reflect.InRightPlace || // Фикс системы, чтобы рефлект отражающего бронежилета работал только тогда, когда он надет в слот взят из ПР Wizard #31902. Автор: BIGZi0348  Imperial Space
             !TryComp<ReflectiveComponent>(projectile, out var reflective) ||
             (reflect.Reflects & reflective.Reflective) == 0x0 ||
             !_random.Prob(reflect.ReflectProb) ||
@@ -165,6 +166,7 @@ public sealed class ReflectSystem : EntitySystem
     {
         if (!TryComp<ReflectComponent>(reflector, out var reflect) ||
             !_toggle.IsActivated(reflector) ||
+            !reflect.InRightPlace || // Фикс системы, чтобы рефлект отражающего бронежилета работал только тогда, когда он надет в слот взят из ПР Wizard #31902. Автор: BIGZi0348 Imperial Space
             !_random.Prob(reflect.ReflectProb))
         {
             newDirection = null;
@@ -193,6 +195,8 @@ public sealed class ReflectSystem : EntitySystem
         if (_gameTiming.ApplyingState)
             return;
 
+        component.InRightPlace = IsInRightPlace(component, args.SlotFlags); // Фикс системы, чтобы рефлект отражающего бронежилета работал только тогда, когда он надет в слот взят из ПР Wizard #31902. Автор: BIGZi0348  Imperial Space
+
         EnsureComp<ReflectUserComponent>(args.Equipee);
     }
 
@@ -205,6 +209,8 @@ public sealed class ReflectSystem : EntitySystem
     {
         if (_gameTiming.ApplyingState)
             return;
+
+        component.InRightPlace = IsInRightPlace(component, SlotFlags.NONE); // Фикс системы, чтобы рефлект отражающего бронежилета работал только тогда, когда он надет в слот взят из ПР Wizard #31902. Автор: BIGZi0348 Imperial Space
 
         EnsureComp<ReflectUserComponent>(args.User);
     }
@@ -235,5 +241,17 @@ public sealed class ReflectSystem : EntitySystem
         }
 
         RemCompDeferred<ReflectUserComponent>(user);
+    }
+    
+    /// <summary>
+    /// Checks if the reflective component should work in designated place. Фикс системы, чтобы рефлект отражающего бронежилета работал только тогда, когда он надет в слот взят из ПР Wizard #31902. Автор: BIGZi0348 Imperial Space
+    /// </summary>
+    
+    private static bool IsInRightPlace(ReflectComponent component, SlotFlags slotFlag)
+    {
+        if (slotFlag == SlotFlags.NONE)
+            return component.ReflectingInHands;
+        else
+            return (component.SlotFlags & slotFlag) == slotFlag;
     }
 }

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -102,6 +102,7 @@
     reflectProb: 1
     reflects:
       - Energy
+    reflectingInHands: false # Фикс системы, чтобы рефлект отражающего бронежилета работал только тогда, когда он надет в слот взят из ПР Wizard #31902. Автор: BIGZi0348  Imperial Space
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseSyndicateContraband ]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -97,7 +97,9 @@
     slots:
     - Back
     - Belt
-  - type: Reflect
+  - type: Reflect # Фикс системы, чтобы рефлект отражающего бронежилета работал только тогда, когда он надет в слот взят из ПР Wizard #31902. Автор: BIGZi0348  Imperial Space
+    slotFlags:
+      - NONE
 
 - type: entity
   name: machete


### PR DESCRIPTION
## Об этом ПР'е:
Является переносом вот этого[ PR'a](https://github.com/space-wizards/space-station-14/pull/31902). Оригинальный автор: [BIGZi0348](https://github.com/BIGZi0348)

## Почему/баланс:
Отражающий бронежилет, имея при себе рефлект проб в единицу, позволяет отражать абсолютно любые хитскан снаряды, которые в него летят. Всё бы ничего, однако его отражающие способности работают на все 100% даже когда персонаж держит его в руке и **НЕ** держит в активном слоте. Отсюда получаем живую машину для убийств, которая может отражать лазерные снаряды и параллельно стрелять с руки. Данный ПР фиксит эту проблему. Теперь бронежилет работает только если надет в слот для брони. Также изменениям подверглась катана ниндзи, которая почему-то отражала снаряды, когда была на поясе

## Технические детали:
ПР скопирован полностью с оригинила. Добавлены наши комментарии обо всех изменениях в коде и прототипах. Указан оригинальный автор ПР'а. Саму сборку проверил. Ошибок нет, механика работает