### PR TITLE
VA-11 Hall-A

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/boozeomat.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/boozeomat.yml
@@ -46,5 +46,6 @@
     DrinkSakeBottleFull: 3
     DrinkBeerCan: 5
     DrinkWineCan: 5
+    DrinkKarmotrineCan: 5 # Imperial Space / VA-11Hall-A
   emaggedInventory:
     DrinkPoisonWinebottleFull: 2

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/drinks_glass.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/drinks_glass.yml
@@ -107,6 +107,30 @@
       - DrinkShakeWhite
       - DrinkTheMartinez
       - DrinkMoonshineGlass
+      - DrinkKarmotrineGlass # start Imperial Space / VA-11Hall-A
+      - DrinkSugarRushGlass
+      - DrinkSparkleStarGlass
+      - DrinkFringeFeaverGlass
+      - DrinkBrandtiniGlass
+      - DrinkBlueFairyGlass
+      - DrinkMarsblastGlass
+      - DrinkMoonblastGlass
+      - DrinkMercuryblastGlass
+      - DrinkGrizzlyTempleGlass
+      - DrinkSunshineCloudGlass
+      - DrinkFluffyDreamGlass
+      - DrinkCobaltVelvetGlass
+      - DrinkBadTouchGlass
+      - DrinkBleedingJaneGlass
+      - DrinkGutPunchGlass
+      - DrinkCreviceSpikeGlass
+      - DrinkZenStarGlass
+      - DrinkPileDriverGlass
+      - DrinkSuplexGlass
+      - DrinkPianomanGlass
+      - DrinkPianowomanGlass
+      - DrinkFrothyWaterGlass
+      - DrinkBloomLightGlass # end Imperial Space / VA-11Hall-A
     chance: 0.8
     offset: 0.0
     #rare


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Изменён стартовый инвентарь АлкоМат'а, содержимое рандомного спавнера стаканов с напитками (в оба были добавлены напитки из разработки VA-11 Hall-A)