### PR TITLE
Fix: Дюп продуктов растений

### DIFF
--- a/Content.Server/Botany/Systems/BotanySystem.Produce.cs
+++ b/Content.Server/Botany/Systems/BotanySystem.Produce.cs
@@ -16,7 +16,15 @@ public sealed partial class BotanySystem
             if (mutation.AppliesToProduce)
             {
                 var args = new EntityEffectBaseArgs(uid, EntityManager);
-                mutation.Effect.Effect(args);
+                // Imperial inf harvest fix
+                try
+                {
+                    mutation.Effect.Effect(args);
+                }
+                catch (KeyNotFoundException)
+                {
+                    Logger.Warning($"Failed to add mutation: {mutation.Name} to {args.TargetEntity} uid");
+                }
             }
         }
 

--- a/Resources/Prototypes/Hydroponics/randomMutations.yml
+++ b/Resources/Prototypes/Hydroponics/randomMutations.yml
@@ -160,15 +160,15 @@
       persists: false
       effect: !type:PlantChangeStat
         targetValue: TurnIntoKudzu
-    # - name: ChangeScreaming // Заблокирована в связи с тем, что может вызывать дюпы Imperial Space
-    #   baseOdds: 0.036
-    #   persists: true # Imperial PlantsAnalyzer (false -> true)
-    #   effect: !type:PlantChangeStat
-    #     targetValue: CanScream
-    # - name: ChangeChemicals // Заблокирована в связи с тем, что может вызывать дюпы Imperial Space
-    #   baseOdds: 0.072
-    #   persists: true # Imperial PlantsAnalyzer (false -> true)
-    #   effect: !type:PlantMutateChemicals
+    - name: ChangeScreaming
+      baseOdds: 0.036
+      persists: true # Imperial PlantsAnalyzer (false -> true)
+      effect: !type:PlantChangeStat
+        targetValue: CanScream
+    - name: ChangeChemicals
+      baseOdds: 0.072
+      persists: true # Imperial PlantsAnalyzer (false -> true)
+      effect: !type:PlantMutateChemicals
     - name: ChangeExudeGasses
       baseOdds: 0.0145
       persists: true # Imperial PlantsAnalyzer (false -> true)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Серьезный фикс дюпа бесконечных продуктов растений у ботаников

## Technical details
<!-- Summary of code changes for easier review. -->
Из-за того, что добавление некоторых мутаций в продукт растения, после сбора урожая в лотке, в коде `BotanySystem.Produce.cs` - вызывает исключение `KeyNotFoundException` в критически важных частях кода системы ботаники, конкретнее до обновлении состояния "сбора урожая" у целевого лотка, при мутации `ChangeHarvest`, которая позволяет собирать урожай несколько раз - соответствующее обновление не происходило, вследствие чего можно было бесконечно собирать урожай.

У визов данная тема нужна, чтобы исключать добавления в продукты растений мутации, которые не должны попадать в них, в соответствии с параметром прототипа: `appliesToProduce`, но сами же не предусмотрели, что в эффектах некоторых мутаций, идёт логика через получение `PlantHolderComponent`, который есть только у лотка, и в котором же храниться информация о семени, уже в которое происходит добавление той или иной мутации.

Также вернул зря отключенные мутации.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
[Botany inf harvest fix](https://github.com/imperial-space/SS14-public/commit/b786de9bd9c237699daead2532a7875a79075bb0)
[Return of random mutations](https://github.com/imperial-space/SS14-public/commit/6eaa3097b1d56636255eeef57bd4d25cff41963f)
