### PR TITLE
added: Глобальный пацифизм после манифеста

### DIFF
--- a/Content.Server/Imperial/GlobalPacifismEndRound/GlobalPacifismEndRoundSystem.cs
+++ b/Content.Server/Imperial/GlobalPacifismEndRound/GlobalPacifismEndRoundSystem.cs
@@ -1,0 +1,35 @@
+using Content.Shared.CombatMode.Pacification;
+using Content.Shared.GameTicking;
+using Content.Shared.Mind.Components;
+
+namespace Content.Server.Imperial.GlobalPacifismEndRound;
+
+public sealed class GlobalPacifismRoundEndSystem : EntitySystem
+{
+
+    private bool _isEnabled = true;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<RoundEndMessageEvent>(OnRoundEnded);
+    }
+
+    private void OnRoundEnded(RoundEndMessageEvent ev)
+    {
+        if (!_isEnabled) return;
+        var mindContainerEnumerator = EntityQueryEnumerator<MindContainerComponent>();
+
+        while (mindContainerEnumerator.MoveNext(out var mindContainer))
+        {
+            try
+            {
+                EnsureComp<PacifiedComponent>(mindContainer.Owner);
+            }
+            catch (Exception e)
+            {
+                Log.Error($"Error adding PacifiedComponent to {mindContainer.Owner} uid: {e}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Возвращение пацифизма после манифеста

## Technical details
<!-- Summary of code changes for easier review. -->
Теперь компонент добавляется всем entity с компонентом `MindContainer`, благодаря чему даже агрессивные мобы без контроля, а также под управлением игрока не смогут атаковать.