### PR TITLE
Изменение цены Фрезона.

### DIFF
--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -99,4 +99,4 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 35
+  pricePerMole: 35 #By Imperial. Цена повышена для изменения баланса Цен относительно тяжести и времени варки.

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -86,7 +86,7 @@
   molarMass: 44
   color: 8F00FF
   reagent: NitrousOxide
-  pricePerMole: 0.1
+  pricePerMole: 10
 
 - type: gas
   id: 8
@@ -99,4 +99,4 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 0.3
+  pricePerMole: 35

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -86,7 +86,7 @@
   molarMass: 44
   color: 8F00FF
   reagent: NitrousOxide
-  pricePerMole: 10
+  pricePerMole: 0.1
 
 - type: gas
   id: 8


### PR DESCRIPTION
## Об этом ПР'е:
Изменение цены Фрезона.

## Почему/баланс:
С обновления от 26.09.2024, для фрезона теперь требуется в ~6 раз больше трития чем раньше (1:8, раньше было 1:50), при этом цена за моль составляет 0,3 кредита. Из-за вышеперечисленных факторов требуется увеличить цену фрезона. Газ являются трудными в варке, а учитывая его стоимость сейчас, это будет одним из лучших решений чтобы фрезон снова использовали для продажи.

## Технические детали:
Цена фрезона повышена до 35 кредитов за моль, что составляет ~595.000 кредитов за полностью охлаждённую канистру фрезона.