### PR TITLE
Изменение костюма ниндзя

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -161,8 +161,8 @@
     parent: true
     components:
     - type: Stealth
-      minVisibility: 0.1
-      lastVisibility: 0.1
+      minVisibility: 0.01
+      lastVisibility: 0.01
   - type: PowerCellDraw
     drawRate: 1.8 # 200 seconds on the default cell
   - type: ToggleCellDraw

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -161,8 +161,8 @@
     parent: true
     components:
     - type: Stealth
-      minVisibility: 0.01
-      lastVisibility: 0.01
+      minVisibility: 0.01 # Imperial Space "0.1 > 0.01" @CrookLv
+      lastVisibility: 0.01 # Imperial Space "0.1 > 0.01" @CrookLv
   - type: PowerCellDraw
     drawRate: 1.8 # 200 seconds on the default cell
   - type: ToggleCellDraw


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Значение видимости костюма ниндзя было изменено с 0.1 на 0.01, силуэт более не видно, только искажения, как и до апстрима.

Сделано с целью того, чтобы аномалию не воспринимали сразу как человека, либо, по крайней мере, не увидели сразу, во избежание меты.

## Media
![image](https://github.com/user-attachments/assets/271e052e-33a3-4ae7-bf55-3e4ff1e498bb)
![image](https://github.com/user-attachments/assets/10a972f1-09d2-428d-938f-3390ed4f2c67)

