### PR TITLE
Mouse Input Helper

### DIFF
--- a/Content.Client/Imperial/Helpers/MouseInputSystem/MouseInputSystem.cs
+++ b/Content.Client/Imperial/Helpers/MouseInputSystem/MouseInputSystem.cs
@@ -1,0 +1,74 @@
+using Content.Shared.Imperial.MouseInput;
+using Content.Shared.Imperial.MouseInput.Events;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.Input;
+using Robust.Client.Player;
+using Robust.Shared.Map;
+
+namespace Content.Client.Imperial.MouseInput;
+
+
+public sealed partial class MouseInputSystem : SharedMouseInputSystem
+{
+    [Dependency] private readonly TransformSystem _transformSystem = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly IInputManager _inputManager = default!;
+    [Dependency] private readonly IEyeManager _eyeManager = default!;
+    [Dependency] private readonly MapSystem _mapSystem = default!;
+
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeNetworkEvent<MousePositionRequestEvent>(OnMousePositionRequest);
+    }
+
+    private void OnMousePositionRequest(MousePositionRequestEvent args)
+    {
+        var player = GetEntity(args.Player);
+
+        if (player != _playerManager.LocalEntity) return;
+        if (!TryGetCursorEntityCoordinates(out var coords)) return;
+
+        RaisePredictiveEvent(new MousePositionResponseEvent()
+        {
+            Coordinates = GetNetCoordinates(coords!.Value),
+            Performer = args.Performer
+        });
+    }
+
+    #region Public API
+
+    public override void CreateMousePositionRequest(EntityUid player, EntityUid? performer = null, TimeSpan? bandwidth = null)
+    {
+        if (!TryGetCursorEntityCoordinates(out var coords)) return;
+
+        RaiseLocalEvent(performer ?? player, new MousePositionRefreshEvent()
+        {
+            MousePosition = coords!.Value,
+            Player = player
+        });
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private bool TryGetCursorEntityCoordinates(out EntityCoordinates? coords)
+    {
+        coords = null;
+
+        var mapPosition = _eyeManager.PixelToMap(_inputManager.MouseScreenPosition);
+
+        if (mapPosition.MapId == MapId.Nullspace) return false;
+        if (!_mapSystem.TryGetMap(mapPosition.MapId, out var mapUid)) return false;
+
+        coords = _transformSystem.ToCoordinates(mapUid.Value, mapPosition);
+
+        return true;
+    }
+
+    #endregion
+}

--- a/Content.Client/Imperial/Helpers/MouseInputSystem/license.txt
+++ b/Content.Client/Imperial/Helpers/MouseInputSystem/license.txt
@@ -1,0 +1,2 @@
+license: This content is under ICLA. Copyright holder: orix0689 (discord) (Read more on: https://wiki.imperialspace.net/ru/icla)
+copyright: "orix0689 (discord)"

--- a/Content.Server/Imperial/Helpers/MouseInputSystem/MouseInputSystem.cs
+++ b/Content.Server/Imperial/Helpers/MouseInputSystem/MouseInputSystem.cs
@@ -1,0 +1,37 @@
+
+using Content.Shared.Imperial.MouseInput;
+using Content.Shared.Imperial.MouseInput.Events;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+
+namespace Content.Server.Imperial.MouseInput;
+
+
+public sealed partial class MouseInputSystem : SharedMouseInputSystem
+{
+    #region Public API
+
+    public override void CreateMousePositionRequest(EntityUid player, EntityUid? performer = null, TimeSpan? bandwidth = null)
+    {
+        if (!HasComp<ActorComponent>(player)) return;
+
+        if (TryGetCache(player, out var cachedCoords))
+        {
+            UpdateCache(player, cachedCoords!.Value);
+            RaiseLocalEvent(performer ?? player, new MousePositionRefreshEvent()
+            {
+                MousePosition = cachedCoords!.Value,
+                Player = player,
+            });
+        }
+
+        UpdateCache(player, EntityCoordinates.Invalid, bandwidth);
+        RaiseNetworkEvent(new MousePositionRequestEvent()
+        {
+            Performer = GetNetEntity(performer ?? player),
+            Player = GetNetEntity(player)
+        }, player);
+    }
+
+    #endregion
+}

--- a/Content.Server/Imperial/Helpers/MouseInputSystem/license.txt
+++ b/Content.Server/Imperial/Helpers/MouseInputSystem/license.txt
@@ -1,0 +1,2 @@
+license: This content is under ICLA. Copyright holder: orix0689 (discord) (Read more on: https://wiki.imperialspace.net/ru/icla)
+copyright: "orix0689 (discord)"

--- a/Content.Shared/Imperial/Helpers/MouseInputSystem/Events/MousePositionRefreshEvent.cs
+++ b/Content.Shared/Imperial/Helpers/MouseInputSystem/Events/MousePositionRefreshEvent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.Map;
+
+namespace Content.Shared.Imperial.MouseInput.Events;
+
+
+public sealed class MousePositionRefreshEvent : EntityEventArgs
+{
+    public EntityCoordinates MousePosition;
+
+    public EntityUid Player;
+}

--- a/Content.Shared/Imperial/Helpers/MouseInputSystem/Events/Network/MousePositionRequestEvent.cs
+++ b/Content.Shared/Imperial/Helpers/MouseInputSystem/Events/Network/MousePositionRequestEvent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Imperial.MouseInput.Events;
+
+
+[Serializable, NetSerializable]
+public sealed class MousePositionRequestEvent : EntityEventArgs
+{
+    public NetEntity Performer;
+
+    public NetEntity Player;
+}

--- a/Content.Shared/Imperial/Helpers/MouseInputSystem/Events/Network/MousePositionResponseEvent.cs
+++ b/Content.Shared/Imperial/Helpers/MouseInputSystem/Events/Network/MousePositionResponseEvent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Imperial.MouseInput.Events;
+
+
+[Serializable, NetSerializable]
+public sealed class MousePositionResponseEvent : EntityEventArgs
+{
+    public NetCoordinates Coordinates;
+
+    public NetEntity Performer;
+}

--- a/Content.Shared/Imperial/Helpers/MouseInputSystem/SharedMouseInputSystem.cs
+++ b/Content.Shared/Imperial/Helpers/MouseInputSystem/SharedMouseInputSystem.cs
@@ -1,0 +1,80 @@
+using Content.Shared.Imperial.MouseInput.Events;
+using Robust.Shared.Map;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.Imperial.MouseInput;
+
+
+public abstract class SharedMouseInputSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+
+    private TimeSpan _bandwidth = TimeSpan.FromSeconds(0.5f);
+    private Dictionary<EntityUid, (EntityCoordinates, TimeSpan, TimeSpan)> _cache = new();
+
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeAllEvent<MousePositionResponseEvent>(OnMousePositionResponse);
+    }
+
+    private void OnMousePositionResponse(MousePositionResponseEvent args, EntitySessionEventArgs session)
+    {
+        if (session.SenderSession.AttachedEntity == null) return;
+
+        var coords = GetCoordinates(args.Coordinates);
+        var performer = GetEntity(args.Performer);
+
+        UpdateCache(session.SenderSession.AttachedEntity.Value, coords);
+        RaiseLocalEvent(performer, new MousePositionRefreshEvent()
+        {
+            MousePosition = coords,
+            Player = session.SenderSession.AttachedEntity.Value
+        });
+    }
+
+    #region Public API
+
+    public virtual void CreateMousePositionRequest(EntityUid player, EntityUid? performer = null, TimeSpan? bandwidth = null)
+    {
+    }
+
+    #endregion
+
+    #region Helpers
+
+    protected bool TryGetCache(EntityUid player, out EntityCoordinates? coords)
+    {
+        coords = null;
+
+        if (!_cache.TryGetValue(player, out var cache)) return false;
+        if (cache.Item3 + cache.Item2 < _timing.CurTime) return false;
+
+        coords = cache.Item1;
+
+        return true;
+    }
+
+    protected void UpdateCache(EntityUid player, EntityCoordinates coords, TimeSpan? bandwidth = null)
+    {
+        if (_cache.TryGetValue(player, out var cache))
+        {
+            if (!coords.IsValid(EntityManager)) return;
+
+            _cache[player] = (
+                coords,
+                bandwidth ?? cache.Item2,
+                _timing.CurTime
+            );
+
+            return;
+        }
+
+        _cache.Add(player, (coords, bandwidth ?? _bandwidth, TimeSpan.Zero));
+    }
+
+    #endregion
+}

--- a/Content.Shared/Imperial/Helpers/MouseInputSystem/license.txt
+++ b/Content.Shared/Imperial/Helpers/MouseInputSystem/license.txt
@@ -1,0 +1,2 @@
+license: This content is under ICLA. Copyright holder: orix0689 (discord) (Read more on: https://wiki.imperialspace.net/ru/icla)
+copyright: "orix0689 (discord)"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Добавляет систему дающую доступ к позиции мыши выбранного клиента.

## Technical details
Предоставляет метод CreateMousePositionRequest с разными реализациями в зависимости от среды выполнения(Клиент/Сервер). В ответ присылается ивент MousePositionResponseEvent, который содержит позицию курсора игрока.

В параметре bandwidth выбирается максимальная пропускная способность. Если время с последнего запроса меньше, чем пропускная способность у наблюдателя за сущностью, то возвращается кешированное положение курсора. Если на сущность подписалось несколько систем, то выбирается наименьшая пропускная способность.

Для клиента возвращается ивента игнорирующий пропускную способность.