### PR TITLE
Hristov buff

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -152,9 +152,9 @@
   productEntity: BriefcaseSyndieSniperBundleFilled
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 6
+    Telecrystal: 7
   cost:
-    Telecrystal: 12
+    Telecrystal: 15
   categories:
   - UplinkWeaponry
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -152,9 +152,9 @@
   productEntity: BriefcaseSyndieSniperBundleFilled
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 7
+    Telecrystal: 7 # Imperial balance
   cost:
-    Telecrystal: 15
+    Telecrystal: 15 # Imperial balance
   categories:
   - UplinkWeaponry
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -74,12 +74,16 @@
     capacity: 5
     proto: CartridgeAntiMateriel
   - type: SpeedModifiedOnWield
-    walkModifier: 0.70
-    sprintModifier: 0.70
+    walkModifier: 0.70 # Imperial balance
+    sprintModifier: 0.70 # Imperial balance
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
     maxOffset: 3
     pvsIncrease: 0.3
+  - type: GunWieldBonus # Imperial balance
+    minAngle: -32
+    maxAngle: -32
+    
 
 - type: entity
   name: musket

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -59,6 +59,8 @@
     sprite: Objects/Weapons/Guns/Snipers/heavy_sniper.rsi
   - type: GunRequiresWield
   - type: Gun
+    projectileSpeed: 50
+    projectileSpeedModified: 50
     fireRate: 0.4
     selectedMode: SemiAuto
     availableModes:
@@ -72,8 +74,8 @@
     capacity: 5
     proto: CartridgeAntiMateriel
   - type: SpeedModifiedOnWield
-    walkModifier: 0.25
-    sprintModifier: 0.25
+    walkModifier: 0.17
+    sprintModifier: 0.17
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
     maxOffset: 3

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -59,8 +59,8 @@
     sprite: Objects/Weapons/Guns/Snipers/heavy_sniper.rsi
   - type: GunRequiresWield
   - type: Gun
-    projectileSpeed: 50
-    projectileSpeedModified: 50
+    projectileSpeed: 50 # Imperial Balance
+    projectileSpeedModified: 50 # Imperial Balance
     fireRate: 0.4
     selectedMode: SemiAuto
     availableModes:
@@ -74,8 +74,8 @@
     capacity: 5
     proto: CartridgeAntiMateriel
   - type: SpeedModifiedOnWield
-    walkModifier: 0.17
-    sprintModifier: 0.17
+    walkModifier: 0.70
+    sprintModifier: 0.70
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
     maxOffset: 3

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -83,7 +83,6 @@
   - type: GunWieldBonus # Imperial balance
     minAngle: -32
     maxAngle: -32
-    
 
 - type: entity
   name: musket


### PR DESCRIPTION
## About the PR
Баффает христов, повышая скорость проджектайла и уменьшая замедление.

## Why / Balance
Поиграл я с этим вашим христовым и скажу так - он стал лишь хуже. Мобильность делится на ноль и стреляет НУ УБЕР косо для снайперской лонг-рендж винтовки.

Решение проблемы:

* Увеличиваем скорость проджектайла вдвое
* Уменьшаем замедление с 0.25 до 0.70
* Увеличиваем вилд бонус так, чтобы промазать было невозможно.
* Увеличиваем цену в аплинке до 15 тк.