### PR TITLE
СБ борги теперь могут брать наручники!

### DIFF
--- a/Content.Shared/Imperial/ImperialBorgs/ImperialBorgHandsComponent.cs
+++ b/Content.Shared/Imperial/ImperialBorgs/ImperialBorgHandsComponent.cs
@@ -1,0 +1,32 @@
+using Content.Shared.Item;
+using Content.Shared.Tag;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Borgs.Imperial;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class BorgHandsImperialSecurityComponent : Component // Компонент для СБ борга Империала
+{
+    // Этот компонент не содержит никаких данных, он просто служит маркером.
+}
+
+public sealed partial class BorgHandsImperialSystem : EntitySystem
+{
+    [Dependency] private readonly TagSystem _tagSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BorgHandsImperialSecurityComponent, PickupAttemptEvent>(OnPickupAttempt);
+    }
+
+
+    public void OnPickupAttempt(EntityUid uid, BorgHandsImperialSecurityComponent component, PickupAttemptEvent args)
+    {
+        if (_tagSystem.HasAnyTag(args.Item, "SecurityBorgItem")) return;
+
+        args.Cancel();
+    }
+
+}

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -16,6 +16,7 @@
   - type: Tag
     tags:
     - Handcuffs
+    - SecurityBorgItem # Тег, позволяющий СБ боргу брать данный предмет Imperial Space
   - type: MeleeWeapon
     wideAnimationRotation: 90
     resetOnHandSelected: false

--- a/Resources/Prototypes/Imperial/Roles/Jobs/Synthetics/SecurityCyborg.yml
+++ b/Resources/Prototypes/Imperial/Roles/Jobs/Synthetics/SecurityCyborg.yml
@@ -30,6 +30,14 @@
   - type: ShowMindShieldIcons
   - type: ShowCriminalRecordIcons
   - type: FlashImmunity
+  - type: Body
+    prototype: ImperialBorg
+  - type: MobThresholds
+    thresholds:
+     0: Alive
+     200: Critical
+     300: Dead
+  - type: BorgHandsImperialSecurity
 
   radioChannels:
   - Security
@@ -61,3 +69,18 @@
   - /Audio/Imperial/Synthetics/sound_misc_step_step_robo_1.ogg
   - /Audio/Imperial/Synthetics/sound_misc_step_step_robo_2.ogg
   - /Audio/Imperial/Synthetics/sound_misc_step_step_robo_3.ogg
+
+- type: body
+  id: ImperialBorg # Тело для киборгов Империала, чтобы у них была рука
+  name: "Imperial borg"
+  root: torso
+  slots:
+    torso:
+      part: TorsoAnimal
+      connections:
+      - hand
+    hand:
+      part: HandsAnimal
+
+- type: Tag
+  id: SecurityBorgItem # Тег, позволяющий СБ боргу брать предметы Imperial Space


### PR DESCRIPTION
## О ПР`е
<!-- Что вы поменяли? -->
СБ боргу добавлена рука с вайтлистом на предметы, имеющие определенный тег. Также повышено ХП СБ борга. 
## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->
* Сделан новый компонент пустышка, который повешен на СБ борга `BorgHandsImperialSecurityComponent`
* Написана система, проверяющая, есть ли у предмета тег `SecurityBorgItem`. Только предметы с данным тегом СБ борг может подбирать
* Сделан тег SecurityBorgItem
* Добавлен новый тип тела для боргов Империала на будущее, дарующий им руку
* Количество ХП СБ борга увеличено в 2 раза. Теперь крит с 200 ХП.
## Изменения кода официальных разработчиков 
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->
* На наручники был добавлен новый тег SecurityBorgItem. Теперь СБ борг может брать их!