### PR TITLE
Карго прайсмодифер для автолатов, протолатов

### DIFF
--- a/Content.Server/Cargo/Systems/PricingSystem.cs
+++ b/Content.Server/Cargo/Systems/PricingSystem.cs
@@ -23,7 +23,7 @@ namespace Content.Server.Cargo.Systems;
 /// <summary>
 /// This handles calculating the price of items, and implements two basic methods of pricing materials.
 /// </summary>
-public sealed class PricingSystem : EntitySystem
+public sealed partial class PricingSystem : EntitySystem // Imperial Lathes Nerf made it partial
 {
     [Dependency] private readonly IComponentFactory _factory = default!;
     [Dependency] private readonly IConsoleHost _consoleHost = default!;
@@ -208,7 +208,7 @@ public sealed class PricingSystem : EntitySystem
 
         // TODO: Proper container support.
 
-        return price;
+        return ApplyPrototypePriceModifier(prototype, price); // Imperial Lathe Nerf
     }
 
     /// <summary>
@@ -254,7 +254,7 @@ public sealed class PricingSystem : EntitySystem
             }
         }
 
-        return price;
+        return ApplyPriceModifier(uid, price); // Imperial Lathe Nerf
     }
 
     private double GetMaterialsPrice(EntityUid uid)

--- a/Content.Server/Imperial/Cargo/Components/PriceModiferComponent.cs
+++ b/Content.Server/Imperial/Cargo/Components/PriceModiferComponent.cs
@@ -1,0 +1,8 @@
+namespace Content.Server.Imperial.Cargo.Components;
+
+[RegisterComponent]
+public sealed partial class PriceModifierComponent : Component
+{
+    [DataField]
+    public float Modifier;
+}

--- a/Content.Server/Imperial/Cargo/Systems/PricingSystem.Modifier.cs
+++ b/Content.Server/Imperial/Cargo/Systems/PricingSystem.Modifier.cs
@@ -1,0 +1,33 @@
+using Content.Server.Imperial.Cargo.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Cargo.Systems;
+
+public sealed partial class PricingSystem
+{
+    private double ApplyPrototypePriceModifier(EntityPrototype prototype, double basePrice)
+    {
+        if (prototype.Components.TryGetValue(_factory.GetComponentName(typeof(PriceModifierComponent)),
+                out var modProto))
+        {
+            var priceModifier = (PriceModifierComponent)modProto.Component;
+            return basePrice * priceModifier.Modifier;
+        }
+
+        return basePrice;
+    }
+
+    private double ApplyPriceModifier(EntityUid uid, double basePrice)
+    {
+        if (TryComp<PriceModifierComponent>(uid, out var modifier))
+        {
+            return basePrice * modifier.Modifier;
+        }
+
+        return basePrice;
+    }
+}
+
+// <summary>
+// pls help me
+// <summary>

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -11,6 +11,7 @@ using Content.Server.Power.EntitySystems;
 using Content.Server.PrinterDoc; // Imperial PrinterDoc
 using Content.Server.Radio.EntitySystems;
 using Content.Server.Stack;
+using Content.Server.Imperial.Cargo.Components; // Imperial Lathe Nerf
 using Content.Shared.Atmos;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
@@ -184,7 +185,7 @@ namespace Content.Server.Lathe
             foreach (var (mat, amount) in recipe.Materials)
             {
                 var adjustedAmount = recipe.ApplyMaterialDiscount
-                    ? (int) (-amount * component.MaterialUseMultiplier)
+                    ? (int)(-amount * component.MaterialUseMultiplier)
                     : -amount;
 
                 _materialStorage.TryChangeMaterialAmount(uid, mat, adjustedAmount);
@@ -237,6 +238,7 @@ namespace Content.Server.Lathe
                     var result = Spawn(resultProto, Transform(uid).Coordinates);
                     // Imperial PrinterDoc
                     _printerDoc.TrySetContentPrintedDocument(result, comp.LastUser ?? default, comp.UseCardId);
+                    EnsureComp<PriceModifierComponent>(result).Modifier = comp.PriceModifier; // Imperial Lathe Nerf
                     _stack.TryMergeToContacts(result);
                 }
 

--- a/Content.Shared/Lathe/LatheComponent.cs
+++ b/Content.Shared/Lathe/LatheComponent.cs
@@ -58,6 +58,9 @@ namespace Content.Shared.Lathe
         [DataField, AutoNetworkedField]
         public int DefaultProductionAmount = 1;
 
+        [DataField]
+        public float PriceModifier = 0.3f; // Imperial Lathe Nerf
+
         #region Visualizer info
         [DataField]
         public string? IdleState;

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -613,6 +613,7 @@
       idleState: icon
       runningState: building
       defaultProductionAmount: 10
+      priceModifier: 2 # Imperial Lathe Nerf
       staticPacks:
       - OreSmelting
       - RGlassSmelting


### PR DESCRIPTION
Сделал прайсмодифер для карго, 2f для переработчика руды, а для остальных 0.3f это нужно для избежания создания новых абузных заводов которые Артур фиксит вручную. Так же 2f для переработчика руды заставляет утилей добывать руду для обеспечения деньгами карго.
Затронут код оффов поставлены комментарии 
Такое увидел у DeltaV решил сделать похожее