### PR TITLE
Нерф карго, повышение цен на огнестрел

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Weapons/Guns/SMGs/wt550.rsi
     state: icon
   product: CrateArmorySMG
-  cost: 9000
+  cost: 21000 # Imperial Balance
   category: cargoproduct-category-name-armory
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
     state: icon
   product: CrateArmoryShotgun
-  cost: 7000
+  cost: 17000 # Imperial Balance
   category: cargoproduct-category-name-armory
   group: market
 
@@ -24,7 +24,7 @@
     sprite: Clothing/OuterClothing/Armor/riot.rsi
     state: icon
   product: CrateSecurityRiot
-  cost: 7500
+  cost: 12500 # Imperial Balance
   category: cargoproduct-category-name-armory
   group: market
 
@@ -54,7 +54,7 @@
     sprite: Objects/Weapons/Guns/Battery/laser_gun.rsi
     state: icon
   product: CrateArmoryLaser
-  cost: 4800
+  cost: 9800 # Imperial Balance
   category: cargoproduct-category-name-armory
   group: market
 
@@ -64,6 +64,6 @@
     sprite: Objects/Weapons/Guns/Pistols/mk58.rsi
     state: icon
   product: CrateArmoryPistols
-  cost: 5200
+  cost: 7250 # Imperial Balance
   category: cargoproduct-category-name-armory
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -4,7 +4,7 @@
     sprite: Clothing/OuterClothing/Armor/bulletproof.rsi
     state: icon
   product: CrateSecurityArmor
-  cost: 1250
+  cost: 5500 # Imperial Balance
   category: cargoproduct-category-name-security
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Clothing/Head/Helmets/security.rsi
     state: icon
   product: CrateSecurityHelmet
-  cost: 550
+  cost: 1250 # Imperial Balance
   category: cargoproduct-category-name-security
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Objects/Storage/boxes.rsi
     state: box_security
   product: CrateSecuritySupplies
-  cost: 500
+  cost: 1250 # Imperial Balance
   category: cargoproduct-category-name-security
   group: market
 


### PR DESCRIPTION
## О ПР`е
Значительно увеличивает цену всего огнестрельного оружия в карго.

## Технические детали

- Изменено cargo_armory.yml
- Изменено cargo_security.yml

## Почему/баланс
Сейчас экипаж имеет ОЧЕНЬ легкий доступ к оружию. Вооружить всю станцию можно за жалких 30 минут. Умелый утиль в одиночку выносит около 12 тысяч с одного куска космического мусора. В итоге выходит такая картина:

- Утилизаторы после первой ходки закупают ПП и игнорируя крашеры с ПКА (Что должно являться основным оружием утилизаторов) чистят большой обломок, собирая костюм голиафа и остатки лорда улья на тридцатой минуте.
- ЯО превращается в грушу для битья, так как треть экипажа спокойно вооружается к их прилету.
- Революция легко закупает оружие и давит КМД жилетами на 70% пирс резиста и ту-шот дробовиками.

## Итог
Я считаю что нерф карго в этом плане необходим и он положительно скажется на игровом цикле. Утилизаторы начнут использовать тот арсенал, который для них и задумывался, а ЯО смогут подышать.