### PR TITLE
Ролевые Трейты

### DIFF
--- a/Content.Server/Imperial/PushMarkupOnInit/PushMarkupOnInitComp.cs
+++ b/Content.Server/Imperial/PushMarkupOnInit/PushMarkupOnInitComp.cs
@@ -1,0 +1,8 @@
+namespace Content.Server.Imperial.PushMarkupOnInit;
+
+[RegisterComponent]
+public sealed partial class PushMarkupOnInitComponent : Component
+{
+    [DataField]
+    public string Markup;
+}

--- a/Content.Server/Imperial/PushMarkupOnInit/PushMarkupOnInitSystem.cs
+++ b/Content.Server/Imperial/PushMarkupOnInit/PushMarkupOnInitSystem.cs
@@ -1,0 +1,15 @@
+using Content.Shared.Examine;
+using Content.Server.Imperial.PushMarkupOnInit;
+
+public sealed class PushMarkupOnInitSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<PushMarkupOnInitComponent, ExaminedEvent>(OnExamined);
+    }
+    private void OnExamined(EntityUid uid, PushMarkupOnInitComponent comp, ExaminedEvent args)
+    {
+        args.PushMarkup(Loc.GetString(comp.Markup));
+    }
+}

--- a/Resources/Locale/ru-RU/Imperial/traits.ftl
+++ b/Resources/Locale/ru-RU/Imperial/traits.ftl
@@ -1,0 +1,13 @@
+trait-category-aquila-roleplay = Ролевой Отыгрыш
+
+trait-job-name = Работа
+trait-job-desc = Для тех, кто предпочитает взаимодействие с механиками игры, а не с игроками.
+trait-job = [color=#4d4aff]Работа[/color]
+
+trait-comfyRP-name = Комфортное РП
+trait-comfyRP-desc = Для тех, кто предпочитает спокойные разговоры и размеренное общение без вовлечения в экспериментальный РП процесс.
+trait-comfyRP = [color=#ffa14a]Комфортное РП[/color]
+
+trait-fullRP-name = Продвинутое РП
+trait-fullRP-desc = Для тех, кто не боиться вовлечения в экспериментальные и креативные IC-ситуации и необычный ролевой отыгрыш.
+trait-fullRP = [color=#00c750]Продвинутое РП[/color]

--- a/Resources/Prototypes/Imperial/RolePlayTraits/traits.yml
+++ b/Resources/Prototypes/Imperial/RolePlayTraits/traits.yml
@@ -1,0 +1,34 @@
+- type: traitCategory
+  id: RPTraits
+  name: trait-category-aquila-roleplay
+  maxTraitPoints: 1
+
+- type: trait
+  id: RPJob
+  name: trait-job-name
+  description: trait-job-desc
+  category: RPTraits
+  cost: 1
+  components:
+  - type: PushMarkupOnInit
+    markup: "trait-job"
+
+- type: trait
+  id: RPComfy
+  name: trait-comfyRP-name
+  description: trait-comfyRP-desc
+  category: RPTraits
+  cost: 1
+  components:
+  - type: PushMarkupOnInit
+    markup: "trait-comfyRP"
+
+- type: trait
+  id: RPFull
+  name: trait-fullRP-name
+  description: trait-fullRP-desc
+  category: RPTraits
+  cost: 1
+  components:
+  - type: PushMarkupOnInit
+    markup: "trait-fullRP"


### PR DESCRIPTION
# ДЛЯ МИМОКРОКОДИЛОВ: ИЗМЕНЕНИЯ ТОЛЬКО ДЛЯ WHITELIST СЕРВЕРА
## О ПР`е
Добавлены трейты в кастомизацию, позволяющие указать уровень отыгрыша.

## Технические детали

- Добавлено PushMarkupOnInitSystem.cs по пути Content.Server/Imperial/PushMarkupOnInit
- Добавлено PushMarkupOnInitComp.cs по пути Content.Server/Imperial/PushMarkupOnInit
- Добавлено traits.yml по пути Resources/Prototypes/Imperial/RolePlayTraits
- Добавлено traits.ftl по пути Resources/Locale/ru-RU/Imperial/RolePlayTraits

## Медиа
![отыгрыш](https://github.com/user-attachments/assets/48e5421f-e6a0-429f-b1eb-5c8af7a45e95)
![jobRP](https://github.com/user-attachments/assets/cf44a5ea-3a8d-4529-9be0-09bbd42ccff0)
![fullRP](https://github.com/user-attachments/assets/5048c119-0f85-4eb2-a86d-dce1884c4734)
![comfRP](https://github.com/user-attachments/assets/652d1743-cdb1-4ac8-9e2c-569605d7e38c)
