### PR TITLE
Всем сеньор ролям встроен МШ и добавлен CanBeAntag: false

### DIFF
--- a/Resources/Prototypes/Imperial/Roles/Jobs/Engineering/senior_engineer.yml
+++ b/Resources/Prototypes/Imperial/Roles/Jobs/Engineering/senior_engineer.yml
@@ -10,6 +10,7 @@
   startingGear: SeniorEngineerGear
   icon: "JobIconSeniorEngineer"
   supervisors: job-supervisors-ce
+  canBeAntag: false
   access:
   - Maintenance
   - Engineering
@@ -27,6 +28,9 @@
   - skillMaintenance
   - skillMediumConstruction
   - skillHacking
+  special:
+  - !type:AddImplantSpecial
+    implants: [ MindShieldImplant ]
 
 - type: startingGear
   id: SeniorEngineerGear

--- a/Resources/Prototypes/Imperial/Roles/Jobs/Medical/senior_physician.yml
+++ b/Resources/Prototypes/Imperial/Roles/Jobs/Medical/senior_physician.yml
@@ -16,6 +16,7 @@
   startingGear: SeniorPhysicianGear
   icon: "JobIconSeniorPhysician"
   supervisors: job-supervisors-cmo
+  canBeAntag: false
   access:
   - Medical
   - Maintenance
@@ -29,6 +30,9 @@
   - skillSurgery
   - skillMedicalEquipment
   - skillNeuroSurgery
+  special:
+  - !type:AddImplantSpecial
+    implants: [ MindShieldImplant ]
 
 - type: startingGear
   id: SeniorPhysicianGear

--- a/Resources/Prototypes/Imperial/Roles/Jobs/Science/senior_researcher.yml
+++ b/Resources/Prototypes/Imperial/Roles/Jobs/Science/senior_researcher.yml
@@ -13,6 +13,7 @@
   startingGear: SeniorResearcherGear
   icon: "JobIconSeniorResearcher"
   supervisors: job-supervisors-rd
+  canBeAntag: false
   access:
   - Research
   - Maintenance
@@ -31,6 +32,9 @@
   - skillHacking
   - skillBasicAtmos
   - skillNeuroSurgery
+  special:
+  - !type:AddImplantSpecial
+    implants: [ MindShieldImplant ]
 
 - type: startingGear
   id: SeniorResearcherGear


### PR DESCRIPTION
## О ПР`е
<!-- Что вы поменяли? -->
Всем менторским ролям (Ведущий врач, старший научный сотрудник, ведущий инженер) добавлены импланты МШ и плашка CanBeAntag: false (они не смогут становиться антагонистами более). Я думаю, что данные роли должны в первую очередь обучать новичков, а не заниматься "ловлей" антажки с последующим забиванием на свои прямые обязанности. Если игроки хотят играть за антагонистов - пусть берут роли мидл сегмента отдела, а не занимают роль, за которую мог бы зайти заинтересованный в обучении человек. 
## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->
- Добавлен МШ каждой менторской роли
- Добавлен тумблер, запрещающий им быть антагонистами
## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->
Нулевые, так как роли менторов принадлежат нам. 