### PR TITLE
РнД плазма куттер. 

### DIFF
--- a/Resources/Prototypes/Imperial/Recipes/Devices/PlasmaCutter-devices.yml
+++ b/Resources/Prototypes/Imperial/Recipes/Devices/PlasmaCutter-devices.yml
@@ -6,12 +6,12 @@
   result: EmptyWeaponPlasmaCutter
   categories:
   - Weapons
-  completetime: 5
+  completetime: 4
   materials:
     Steel: 1000
-    Glass: 700
+    Glass: 500
     Plasma: 500
-    Silver: 100
+    Silver: 300
 
 - type: latheRecipePack
   id: SalvagePlasmaCutterWeapons
@@ -25,13 +25,13 @@
   result: Advanced-EmptyWeaponPlasmaCutter
   categories:
   - Weapons
-  completetime: 10
+  completetime: 7
   materials:
     Steel: 1500
     Silver: 1000
     Plasma: 1000
     Glass: 500
-    Gold: 500
+    Gold: 300
 
 - type: latheRecipePack
   id: SalvageAdvancedPlasmaCutterWeapons

--- a/Resources/Prototypes/Imperial/Research/plasmaCutters-arsenal.yml
+++ b/Resources/Prototypes/Imperial/Research/plasmaCutters-arsenal.yml
@@ -8,8 +8,8 @@
     sprite: Imperial/Objects/Weapons/Guns/CharginMaterials/PlasmaCutter/base.rsi
     state: icon
   discipline: Industrial
-  tier: 2
-  cost: 7500
+  tier: 1
+  cost: 5000
   recipeUnlocks:
   - EmptyWeaponPlasmaCutter
 
@@ -21,7 +21,7 @@
     sprite: Imperial/Objects/Weapons/Guns/CharginMaterials/PlasmaCutter/advanced-base.rsi
     state: icon
   discipline: Industrial
-  tier: 3
-  cost: 15000
+  tier: 2
+  cost: 10000
   recipeUnlocks:
   - Advanced-EmptyWeaponPlasmaCutter


### PR DESCRIPTION
## О ПР`е
- Понизил тиры исследования у обычного плазменного резака на 1 (с 2 на 1) и у продвинутого на 1 (с 3 на 2).
- Изменил требуемые очки для исследования.
- Чутка изменил рецепт изготовления. 

Всё из-за неправильной выборки тиров исследования. Игрокам просто не выгодно создавать его. (Например, есть на 3 тире золотой бур, который намного лучше и не требует расходников)

## Технические детали
Resources/Prototypes/Imperial/Recipes/Devices/PlasmaCutter-devices.yml
Resources/Prototypes/Imperial/Research/plasmaCutters-arsenal.yml

## Изменения кода официальных разработчиков
Отсутствуют.
