### PR TITLE
FixPilotingForAncestor

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1400,7 +1400,7 @@
   - type: IdExaminable
   - type: Tag
     tags:
-    - VimPilot
+    - CanPilot # Imperial "FixPilotingForAncestor"
     - DoorBumpOpener
     - AnomalyHost
   - type: Reactive


### PR DESCRIPTION
## О ПР`е
Теперь кобадьды, макаки и все подобные могут управлять шаттлом. Регулировать систему пилотирования для макак будут уже навыки.

## Технические детали
Resources/Prototypes/Entities/Mobs/NPCs/animals.yml

## Изменения кода официальных разработчиков
Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
1403 строчка
