### PR TITLE
Добавление черного списка реагентов в геймрул засорение вентиляций. H/M

### DIFF
--- a/Content.Server/StationEvents/Components/VentClogRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentClogRuleComponent.cs
@@ -51,12 +51,12 @@ public sealed partial class VentClogRuleComponent : Component
         "SpaceLube", "SpaceGlue"
     };
 
-    
+    //Imperial Space; Start
     public IReadOnlyList<string> BlacklistedReagents = new[]
     {
         "UnstableBluespaceLiquid", "ConcentratedBluespaceLiquid"
     };
-
+    //Imperial Space; End
     /// <summary>
     /// Quantity of weak reagents to put in the foam.
     /// </summary>

--- a/Content.Server/StationEvents/Components/VentClogRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentClogRuleComponent.cs
@@ -51,6 +51,12 @@ public sealed partial class VentClogRuleComponent : Component
         "SpaceLube", "SpaceGlue"
     };
 
+    
+    public IReadOnlyList<string> BlacklistedReagents = new[]
+    {
+        "UnstableBluespaceLiquid", "ConcentratedBluespaceLiquid"
+    };
+
     /// <summary>
     /// Quantity of weak reagents to put in the foam.
     /// </summary>

--- a/Content.Server/StationEvents/Components/VentClogRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentClogRuleComponent.cs
@@ -2,7 +2,11 @@
 using Content.Shared.Chemistry.Reagent;
 using Robust.Shared.Audio;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
-
+//Imperial Space; Start
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Content.Shared.Chemistry.Reagent;
+//Imperial Space; End
 namespace Content.Server.StationEvents.Components;
 
 [RegisterComponent, Access(typeof(VentClogRule))]
@@ -52,7 +56,7 @@ public sealed partial class VentClogRuleComponent : Component
     };
 
     //Imperial Space; Start
-    public IReadOnlyList<string> BlacklistedReagents = new[]
+    public List<ProtoId<ReagentPrototype>> BlacklistedReagents = new()
     {
         "UnstableBluespaceLiquid", "ConcentratedBluespaceLiquid"
     };

--- a/Content.Server/StationEvents/Events/VentClogRule.cs
+++ b/Content.Server/StationEvents/Events/VentClogRule.cs
@@ -26,7 +26,7 @@ public sealed class VentClogRule : StationEventSystem<VentClogRuleComponent>
 
         // TODO: "safe random" for chems. Right now this includes admin chemicals.
         var allReagents = PrototypeManager.EnumeratePrototypes<ReagentPrototype>()
-            .Where(x => !x.Abstract && !component.BlacklistedReagents.Contains(x.ID))
+            .Where(x => !x.Abstract && !component.BlacklistedReagents.Contains(x.ID)) //Imperial Space
             .Select(x => x.ID).ToList();
 
         foreach (var (_, transform) in EntityManager.EntityQuery<GasVentPumpComponent, TransformComponent>())

--- a/Content.Server/StationEvents/Events/VentClogRule.cs
+++ b/Content.Server/StationEvents/Events/VentClogRule.cs
@@ -26,7 +26,7 @@ public sealed class VentClogRule : StationEventSystem<VentClogRuleComponent>
 
         // TODO: "safe random" for chems. Right now this includes admin chemicals.
         var allReagents = PrototypeManager.EnumeratePrototypes<ReagentPrototype>()
-            .Where(x => !x.Abstract && !component.BlacklistedReagents.Contains(x.ID)) //Imperial Space
+            .Where(x => !x.Abstract && !component.BlacklistedReagents.Contains(x)) //Imperial Space
             .Select(x => x.ID).ToList();
 
         foreach (var (_, transform) in EntityManager.EntityQuery<GasVentPumpComponent, TransformComponent>())

--- a/Content.Server/StationEvents/Events/VentClogRule.cs
+++ b/Content.Server/StationEvents/Events/VentClogRule.cs
@@ -26,7 +26,7 @@ public sealed class VentClogRule : StationEventSystem<VentClogRuleComponent>
 
         // TODO: "safe random" for chems. Right now this includes admin chemicals.
         var allReagents = PrototypeManager.EnumeratePrototypes<ReagentPrototype>()
-            .Where(x => !x.Abstract)
+            .Where(x => !x.Abstract && !component.BlacklistedReagents.Contains(x.ID))
             .Select(x => x.ID).ToList();
 
         foreach (var (_, transform) in EntityManager.EntityQuery<GasVentPumpComponent, TransformComponent>())


### PR DESCRIPTION
## О ПР`е
<!-- Что вы поменяли? -->
Добавил черный список реагентов к визовскому геймрулу засорения вентиляций, потому что иначе там может появиться 100 унций блюспейс жидкости и телепортировать пол станции в космос.
## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->
VentClogRule.cs
VentClogRuleComponent.cs
## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->
VentClogRule.cs
VentClogRuleComponent.cs