### PR TITLE
Корректировка системы расчета цены. H/M

### DIFF
--- a/Content.Server/Cargo/Systems/PricingSystem.cs
+++ b/Content.Server/Cargo/Systems/PricingSystem.cs
@@ -211,7 +211,7 @@ public sealed partial class PricingSystem : EntitySystem // Imperial Lathes Nerf
 
         var price = ev.Price;
         price += GetMaterialsPrice(prototype);
-        price += GetSolutionsPrice(prototype);
+        // Imperial Lathe Nerf
         // Can't use static price with stackprice
         var oldPrice = price;
         price += GetStackPrice(prototype);
@@ -222,8 +222,11 @@ public sealed partial class PricingSystem : EntitySystem // Imperial Lathes Nerf
         }
 
         // TODO: Proper container support.
-
-        return ApplyPrototypePriceModifier(prototype, price); // Imperial Lathe Nerf
+        // Imperial Lathe Nerf; Start
+        price = ApplyPrototypePriceModifier(prototype, price);
+        price += GetSolutionsPrice(prototype);
+        return price;
+        // Imperial Lathe Nerf; end
     }
 
     /// <summary>
@@ -247,8 +250,7 @@ public sealed partial class PricingSystem : EntitySystem // Imperial Lathes Nerf
         //TODO: Add an OpaqueToAppraisal component or similar for blocking the recursive descent into containers, or preventing material pricing.
         // DO NOT FORGET TO UPDATE ESTIMATED PRICING
         price += GetMaterialsPrice(uid);
-        price += GetSolutionsPrice(uid);
-
+        // Imperial Lathe Nerf
         // Can't use static price with stackprice
         var oldPrice = price;
         price += GetStackPrice(uid);
@@ -270,8 +272,11 @@ public sealed partial class PricingSystem : EntitySystem // Imperial Lathes Nerf
                 }
             }
         }
-
-        return ApplyPriceModifier(uid, price); // Imperial Lathe Nerf
+        // Imperial Lathe Nerf; Start
+        price = ApplyPriceModifier(uid, price);
+        price += GetSolutionsPrice(uid);
+        return price; 
+        // Imperial Lathe Nerf; End
     }
 
     private double GetMaterialsPrice(EntityUid uid)

--- a/Content.Server/Cargo/Systems/PricingSystem.cs
+++ b/Content.Server/Cargo/Systems/PricingSystem.cs
@@ -211,8 +211,7 @@ public sealed partial class PricingSystem : EntitySystem // Imperial Lathes Nerf
 
         var price = ev.Price;
         price += GetMaterialsPrice(prototype);
-        // price += GetSolutionsPrice(prototype);
-        // Imperial Lathe Nerf
+        // price += GetSolutionsPrice(prototype); // Imperial Lathe Nerf
         // Can't use static price with stackprice
         var oldPrice = price;
         price += GetStackPrice(prototype);
@@ -226,6 +225,8 @@ public sealed partial class PricingSystem : EntitySystem // Imperial Lathes Nerf
         // Imperial Lathe Nerf; Start
         price = ApplyPrototypePriceModifier(prototype, price);
         price += GetSolutionsPrice(prototype);
+
+        // return ApplyPrototypePriceModifier(prototype, price); // Imperial Lathe Nerf
         return price;
         // Imperial Lathe Nerf; end
     }
@@ -250,8 +251,8 @@ public sealed partial class PricingSystem : EntitySystem // Imperial Lathes Nerf
         var price = ev.Price;
         //TODO: Add an OpaqueToAppraisal component or similar for blocking the recursive descent into containers, or preventing material pricing.
         // DO NOT FORGET TO UPDATE ESTIMATED PRICING
-        price += GetMaterialsPrice(uid);
-        // Imperial Lathe Nerf
+        price += GetMaterialsPrice(uid);// Imperial Lathe Nerf
+        //price += GetSolutionsPrice(uid); //Imperial Lathe Nerf
         // Can't use static price with stackprice
         var oldPrice = price;
         price += GetStackPrice(uid);
@@ -265,6 +266,7 @@ public sealed partial class PricingSystem : EntitySystem // Imperial Lathes Nerf
         // Imperial Lathe Nerf; Start
         price = ApplyPriceModifier(uid, price);
         price += GetSolutionsPrice(uid);
+        // Imperial Lathe Nerf; End
         if (includeContents && TryComp<ContainerManagerComponent>(uid, out var containers))
         {
             foreach (var container in containers.Containers.Values)
@@ -275,8 +277,9 @@ public sealed partial class PricingSystem : EntitySystem // Imperial Lathes Nerf
                 }
             }
         }
+        //return ApplyPriceModifier(uid, price); // Imperial Lathe Nerf
         return price; 
-        // Imperial Lathe Nerf; End
+        // Imperial Lathe Nerf
     }
 
     private double GetMaterialsPrice(EntityUid uid)

--- a/Content.Server/Cargo/Systems/PricingSystem.cs
+++ b/Content.Server/Cargo/Systems/PricingSystem.cs
@@ -211,6 +211,7 @@ public sealed partial class PricingSystem : EntitySystem // Imperial Lathes Nerf
 
         var price = ev.Price;
         price += GetMaterialsPrice(prototype);
+        // price += GetSolutionsPrice(prototype);
         // Imperial Lathe Nerf
         // Can't use static price with stackprice
         var oldPrice = price;
@@ -261,7 +262,9 @@ public sealed partial class PricingSystem : EntitySystem // Imperial Lathes Nerf
             //Imperial Space Pirates: New Horizon
             price += GetGPSTrackerPrice(uid);
         }
-
+        // Imperial Lathe Nerf; Start
+        price = ApplyPriceModifier(uid, price);
+        price += GetSolutionsPrice(uid);
         if (includeContents && TryComp<ContainerManagerComponent>(uid, out var containers))
         {
             foreach (var container in containers.Containers.Values)
@@ -272,9 +275,6 @@ public sealed partial class PricingSystem : EntitySystem // Imperial Lathes Nerf
                 }
             }
         }
-        // Imperial Lathe Nerf; Start
-        price = ApplyPriceModifier(uid, price);
-        price += GetSolutionsPrice(uid);
         return price; 
         // Imperial Lathe Nerf; End
     }


### PR DESCRIPTION
## О ПР`е
<!-- Что вы поменяли? -->
Теперь цена содержимого сущности (включая реагенты) добавляется к расчету цены только после коэффициента цены от PriceModifierComponent
## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->
Изменения коснулись PricingSystem.cs
## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->
Изменения коснулись PricingSystem.cs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Изменения в логике**
  * Изменён порядок расчёта стоимости: стоимость растворов теперь добавляется после применения модификаторов цены, а не до них. Это влияет на итоговую стоимость предметов с растворами.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->