### PR TITLE
Изменения Рапиры 

### DIFF
--- a/Resources/Prototypes/Imperial/Other/Rapier/rapier.yml
+++ b/Resources/Prototypes/Imperial/Other/Rapier/rapier.yml
@@ -18,13 +18,12 @@
     attackRate: 1.23
     damage:
       types:
-        Piercing: 17
-        Blunt: 2
+        Piercing: 18
     resistanceBypass: true
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Reflect
-    reflectProb: 0.25
+    reflectProb: 0.30
     spread: 90
   - type: SolutionContainerManager
     solutions:

--- a/Resources/Prototypes/Imperial/Other/Rapier/rapier.yml
+++ b/Resources/Prototypes/Imperial/Other/Rapier/rapier.yml
@@ -15,10 +15,11 @@
     wideAnimationRotation: -135
     angle: 0
     animation: WeaponArcThrust
-    attackRate: 1.2
+    attackRate: 1.23
     damage:
       types:
         Piercing: 17
+        Blunt: 2
     resistanceBypass: true
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg

--- a/Resources/Prototypes/Imperial/Other/Rapier/uplink.yml
+++ b/Resources/Prototypes/Imperial/Other/Rapier/uplink.yml
@@ -5,7 +5,7 @@
   icon: { sprite: /Textures/Imperial/Other/Rapier/syndie-rapiera.rsi, state: rapier }
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 9
+    Telecrystal: 12
   productEntity: ClothingBeltSheathRapierFilled
   cost:
     Telecrystal: 14
@@ -24,7 +24,7 @@
   icon: { sprite: /Textures/Imperial/Other/Rapier/syndie-rapiera.rsi, state: rapier }
   productEntity: ClothingBeltSheathRapierFilled
   cost:
-    Telecrystal: 19
+    Telecrystal: 18
   categories:
   - UplinkWeaponry
   conditions:


### PR DESCRIPTION
## О ПР`е
<!-- Что вы поменяли? -->
Понизил цену рапиры в аплинке ядеров до 18 ТК (Было 19)
Сменил атакрейт у рапиры
Слегка баффнул урон рапиры (Upd: убрал дробящий, но повысил урон пирсингу на 1)
Понизил скидку на рапиру до 12 ТК
Повысил шанс отражения, что бы сделать рапиру грейт агаин, ну и потому что она была слишком ситлуативной подходила против ходящей рп брони, но в обычных файтах уступала есворду ну и просто потому что у нее атака на лкм и пкм только для робустиков там попадать надо
(Все эти изменения, что бы анробастики тоже могли играться с рапирой) я тоже анробастик
ББешки все равно имбовее, увы
## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->

## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Баланс**
  * Увеличена скорость атаки рапиры.
  * Повышен урон колющим типом с 17 до 18.
  * Повышена вероятность отражения с 25% до 30%.
  * Цена рапиры в аплинке повышена с 9 до 12 телекристаллов.
  * Цена варианта «UplinkNukiesRapier» снижена с 19 до 18 телекристаллов.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->