### PR TITLE
Fix Металлоискатель

### DIFF
--- a/Content.Server/Imperial/Crook/Systems/MetalDetectorSystem.cs
+++ b/Content.Server/Imperial/Crook/Systems/MetalDetectorSystem.cs
@@ -110,8 +110,13 @@ namespace Content.Server.Imperial.Crook.Systems
             if (currentDepth > maxDepth)
                 return false;
 
-            if (HasComp<ContrabandComponent>(entity))
+            if (TryComp<ContrabandComponent>(entity, out var contraband))
+            {
+                if (IsContrabandAllowed(detector, entity))
+                    return false;
+
                 return true;
+            }
 
             if (TryComp<InventoryComponent>(entity, out var inventory))
             {
@@ -148,8 +153,8 @@ namespace Content.Server.Imperial.Crook.Systems
         }
 
         private void HandleDetectionResults(EntityUid detector, EntityUid entity,
-                                 MetalDetectorComponent comp,
-                                 bool hasContraband)
+                         MetalDetectorComponent comp,
+                         bool hasContraband)
         {
             if (HasRequiredAccess(entity, comp))
             {
@@ -178,12 +183,91 @@ namespace Content.Server.Imperial.Crook.Systems
 
             if (hasContraband && comp.CheckContraband)
             {
-                SetStateWithSound(detector, MetalDetectorVisualState.Alert, comp, comp.AlertSound);
+                if (HasUnauthorizedContraband(entity))
+                {
+                    SetStateWithSound(detector, MetalDetectorVisualState.Alert, comp, comp.AlertSound);
+                }
+                else
+                {
+                    SetStateWithSound(detector, MetalDetectorVisualState.Scanning, comp, comp.ClearSound);
+                }
             }
             else
             {
                 SetStateWithSound(detector, MetalDetectorVisualState.Scanning, comp, comp.ClearSound);
             }
+        }
+
+        private bool HasUnauthorizedContraband(EntityUid user)
+        {
+            if (TryComp<InventoryComponent>(user, out var inventory))
+            {
+                foreach (var slotDef in inventory.Slots)
+                {
+                    if (_inventory.TryGetSlotEntity(user, slotDef.Name, out var item) &&
+                        HasContrabandRecursive(item.Value, user))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            foreach (var heldItem in _hands.EnumerateHeld(user))
+            {
+                if (HasContrabandRecursive(heldItem, user))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool HasContrabandRecursive(EntityUid item, EntityUid user, int depth = 0, int maxDepth = 5)
+        {
+            if (depth > maxDepth)
+                return false;
+
+            if (HasComp<ContrabandComponent>(item) && !IsContrabandAllowed(user, item))
+                return true;
+
+            if (TryComp<ContainerManagerComponent>(item, out var containerManager))
+            {
+                foreach (var container in containerManager.Containers.Values)
+                {
+                    foreach (var containedItem in container.ContainedEntities)
+                    {
+                        if (HasContrabandRecursive(containedItem, user, depth + 1, maxDepth))
+                            return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private bool IsContrabandAllowed(EntityUid user, EntityUid contrabandItem)
+        {
+            if (!TryComp<ContrabandComponent>(contrabandItem, out var contraband))
+                return false;
+
+            if (!_idCard.TryFindIdCard(user, out var idCard))
+                return false;
+
+            if (idCard.Comp.JobDepartments.Intersect(contraband.AllowedDepartments).Any())
+                return true;
+
+            if (idCard.Comp.JobPrototype != null)
+            {
+                var jobId = idCard.Comp.JobPrototype.Value;
+                foreach (var allowedJob in contraband.AllowedJobs)
+                {
+                    if (allowedJob == jobId)
+                        return true;
+                }
+            }
+
+            return false;
         }
 
         private void SetState(EntityUid uid, MetalDetectorVisualState state, MetalDetectorComponent comp)

--- a/Content.Server/Imperial/Crook/Systems/MetalDetectorSystem.cs
+++ b/Content.Server/Imperial/Crook/Systems/MetalDetectorSystem.cs
@@ -220,6 +220,18 @@ namespace Content.Server.Imperial.Crook.Systems
                 }
             }
 
+            if (TryComp<ContainerManagerComponent>(user, out var containerManager))
+            {
+                foreach (var container in containerManager.Containers.Values)
+                {
+                    foreach (var containedItem in container.ContainedEntities)
+                    {
+                        if (HasContrabandRecursive(containedItem, user))
+                            return true;
+                    }
+                }
+            }
+
             return false;
         }
 

--- a/Resources/Prototypes/Imperial/MetalDetector/machine.yml
+++ b/Resources/Prototypes/Imperial/MetalDetector/machine.yml
@@ -197,8 +197,8 @@
   completetime: 8
   materials:
     Plasma: 100
-    Steel: 150
-    Gold: 10
+    Steel: 200
+    Gold: 50
 
 - type: technology
   id: MetalDetectorTech


### PR DESCRIPTION
## О ПР`е
<!-- Что вы поменяли? -->
Исправлен баг, при котором детектор реагировал на разрешённую по профессии контрабанду.
Например, на сервисную гарнитуру у клоуна.
Сделал крафт металлоискателя немного дороже.
## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->

## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Улучшено обнаружение контрабанды: система теперь учитывает разрешённость контрабанды по должности и отделу пользователя, оповещения срабатывают только при обнаружении неразрешённой контрабанды.
  * Обновлены требования к материалам для создания схемы металлоискателя: увеличено количество стали и золота.
* **Исправления ошибок**
  * Исправлено ложное срабатывание детектора на разрешённую контрабанду для определённых ролей.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->