### PR TITLE
Изменение цен газов.

### DIFF
--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -99,4 +99,4 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 35 #By Imperial. Цена повышена для изменения баланса Цен относительно тяжести и времени варки.
+  pricePerMole: 6 # Imperial Atmos changes

--- a/Resources/Prototypes/Imperial/Atmospherics/Ozonium/gas.yml
+++ b/Resources/Prototypes/Imperial/Atmospherics/Ozonium/gas.yml
@@ -9,4 +9,4 @@
   gasMolesVisible: 0.2
   color: 00a352
   reagent: Ozonium
-  pricePerMole: 4
+  pricePerMole: 2

--- a/Resources/Prototypes/Imperial/Atmospherics/Phazonium/gas.yml
+++ b/Resources/Prototypes/Imperial/Atmospherics/Phazonium/gas.yml
@@ -9,4 +9,4 @@
   gasMolesVisible: 0.6
   color: 4B0082
   reagent: Phazonium
-  pricePerMole: 220
+  pricePerMole: 80

--- a/Resources/Prototypes/Imperial/Atmospherics/Thermonium/gas.yml
+++ b/Resources/Prototypes/Imperial/Atmospherics/Thermonium/gas.yml
@@ -9,4 +9,4 @@
   gasMolesVisible: 0.6
   color: FFA500
   reagent: Thermonium
-  pricePerMole: 20
+  pricePerMole: 10


### PR DESCRIPTION
## О ПР`е
Изменены цены на газы. Сделано в целях сделать варку и количество получаемых кредитов более сбалансированными.

Цена фрезона снижена до 6 кредитов/моль (Примерно: 133 176 кредитов за канистру)
Цена Термонуима снижена до 10 кредитов/моль (Примерно: 221 960 кредитов за канистру)
Цена Фазона снижена до 80 кредитов/моль (Примерно: 10 690 800 кредитов за канистру)
Цена Озона снижена до 2 кредитов/моль (Примерно: 44 392 кредитов за канистру)


## Изменения кода официальных разработчиков
gases.yml
