### PR TITLE
Fix supermatter

### DIFF
--- a/Content.Server/Imperial/Power/EntitySystems/SupermatterIntegritySystem.cs
+++ b/Content.Server/Imperial/Power/EntitySystems/SupermatterIntegritySystem.cs
@@ -64,46 +64,44 @@ namespace Content.Server.Imperial.Power.EntitySystems
 
         private void ProcessSupermatterUpdate(EntityUid uid, SupermatterIntegrityComponent comp, TransformComponent transComp, float frameTime)
         {
-            var gas = _atmosphereSystem.GetContainingMixture((uid, transComp), true);
 
-            var badConditions = false;
+            var gas = _atmosphereSystem.GetContainingMixture((uid, transComp), true, true);
+            bool badConditions = false;
             if (gas != null)
             {
-                if (gas.Temperature > comp.UpperTempThreshold ||
-                    gas.Temperature < comp.LowerTempThreshold ||
-                    gas.Pressure > comp.UpperPressureThreshold)
-                {
-                    badConditions = true;
-                }
+                badConditions = gas.Temperature > comp.UpperTempThreshold ||
+                                gas.Temperature < comp.LowerTempThreshold ||
+                                gas.Pressure > comp.UpperPressureThreshold;
+            }
+            else
+            {
+                badConditions = true;
             }
 
-            var integrityPercent = comp.Integrity / comp.MaxIntegrity * 100;
+            var integrityPercent = comp.Integrity / comp.MaxIntegrity * 100f;
 
+            // Сброс флага предупреждения для текущего уровня
             var index = comp.SupermatterIntegrity.FindIndex(entry => integrityPercent > entry.Threshold);
             if (index >= 0)
             {
-                // Replace with same tuple but Flag = false
                 var oldEntry = comp.SupermatterIntegrity[index];
-                comp.SupermatterIntegrity[index] = (oldEntry.Threshold, oldEntry.Color, oldEntry.Description, oldEntry.Warning, false);
+                if (oldEntry.Flag)
+                    comp.SupermatterIntegrity[index] = (oldEntry.Threshold, oldEntry.Color, oldEntry.Description, oldEntry.Warning, false);
             }
 
             foreach (var level in comp.SupermatterIntegrity.OrderByDescending(entry => entry.Threshold))
             {
-                if (integrityPercent > level.Threshold
-                    || level.Flag
-                    || string.IsNullOrEmpty(level.Warning))
-                {
+                if (integrityPercent > level.Threshold || level.Flag || string.IsNullOrEmpty(level.Warning))
                     continue;
-                }
 
                 var integrityWarning = Loc.GetString(level.Warning);
-
                 SendSupermatterRadio(uid, integrityWarning, comp);
 
-                var criticalThreshold = comp.SupermatterIntegrity.MinBy(entry => entry.Threshold);
-                if (integrityPercent <= criticalThreshold.Threshold) // 10f
+                // Если мы достигли уровня с порогом <= 10% — выставляем код тревоги для станции и объявление.
+                // Раньше использовался MinBy по всем порогам (что возвращало 0) и из-за этого код не ставился.
+                if (level.Threshold <= 10f)
                 {
-                    var station = _stationSystem.GetOwningStation(uid);
+                    var station = _stationSystem.GetOwningStation(uid, transComp);
                     if (station != null)
                     {
                         _alertLevelSystem.SetLevel(station.Value, "yellow", true, true, true);
@@ -114,15 +112,15 @@ namespace Content.Server.Imperial.Power.EntitySystems
                             colorOverride: Color.Yellow
                         );
                     }
-                    EntityManager.QueueDeleteEntity(uid);
-                    return;
                 }
 
+                // Устанавливаем флаг предупреждения
                 var levelIndex = comp.SupermatterIntegrity.FindIndex(entry => Math.Abs(level.Threshold - entry.Threshold) < 1f);
-                var updated = comp.SupermatterIntegrity[levelIndex];
-
-                comp.SupermatterIntegrity[levelIndex] = (updated.Threshold, updated.Color, updated.Description, updated.Warning, true);
-
+                if (levelIndex >= 0)
+                {
+                    var updated = comp.SupermatterIntegrity[levelIndex];
+                    comp.SupermatterIntegrity[levelIndex] = (updated.Threshold, updated.Color, updated.Description, updated.Warning, true);
+                }
                 break;
             }
 
@@ -134,7 +132,7 @@ namespace Content.Server.Imperial.Power.EntitySystems
                 comp.CatastropheLightningTimer = TimeSpan.Zero; // Сбрасываем таймер молний
 
                 // Отправляем предупреждение о катастрофе
-                var station = _stationSystem.GetOwningStation(uid);
+                var station = _stationSystem.GetOwningStation(uid, transComp);
                 if (station != null)
                 {
                     _alertLevelSystem.SetLevel(station.Value, "red", true, true, true);
@@ -182,21 +180,15 @@ namespace Content.Server.Imperial.Power.EntitySystems
             }
 
             // Обработка урона от плохих условий
-            if (!badConditions)
-                return;
-
-            comp.TickAccumulator += TimeSpan.FromSeconds(frameTime);
-            while (comp.TickAccumulator >= comp.DamageTickInterval)
+            if (badConditions)
             {
-                comp.TickAccumulator -= comp.DamageTickInterval;
-
-                var tickAmount = 0f;
-                foreach (var v in comp.TickDamage.DamageDict.Values)
+                comp.TickAccumulator += TimeSpan.FromSeconds(frameTime);
+                while (comp.TickAccumulator >= comp.DamageTickInterval)
                 {
-                    tickAmount += (float)v;
+                    comp.TickAccumulator -= comp.DamageTickInterval;
+                    var tickAmount = comp.TickDamage.DamageDict.Values.Sum(v => (float)v);
+                    comp.Integrity = MathF.Max(0, comp.Integrity - tickAmount);
                 }
-
-                comp.Integrity = MathF.Max(0, comp.Integrity - tickAmount);
             }
         }
 

--- a/Content.Server/Imperial/Power/EntitySystems/SupermatterMonitorConsoleSystem.cs
+++ b/Content.Server/Imperial/Power/EntitySystems/SupermatterMonitorConsoleSystem.cs
@@ -103,7 +103,8 @@ namespace Content.Server.Imperial.Power.EntitySystems
                 var (integrityPercent, level) = CalculateIntegrity(nearest);
                 var integrity = (int)Math.Round(integrityPercent);
 
-                if (integrity >= nearest.SupermatterIntegrity.Min().Threshold)
+                var highestThreshold = nearest.SupermatterIntegrity.MaxBy(e => e.Threshold).Threshold;
+                if (integrity >= highestThreshold)
                 {
                     console.BeepCooldownTimer = TimeSpan.Zero;
                 }
@@ -123,8 +124,21 @@ namespace Content.Server.Imperial.Power.EntitySystems
             CalculateIntegrity(SupermatterIntegrityComponent component)
         {
             var integrity = component.Integrity / component.MaxIntegrity * 100f;
-            var integrityLevel = component.SupermatterIntegrity.First(entry => integrity > entry.Threshold);
-            return (integrity, integrityLevel);
+
+            // Выбираем самый высокий уровень, порог которого меньше или равен текущей целостности.
+            var ordered = component.SupermatterIntegrity.OrderByDescending(e => e.Threshold).ToList();
+            var idx = ordered.FindIndex(entry => integrity >= entry.Threshold);
+            (float Threshold, Color Color, LocId Description, LocId Warning, bool Flag) level;
+            if (idx >= 0)
+            {
+                level = ordered[idx];
+            }
+            else
+            {
+                level = component.SupermatterIntegrity.MinBy(e => e.Threshold);
+            }
+
+            return (integrity, level);
         }
     }
 }

--- a/Resources/Locale/ru-RU/Imperial/entities/supermatter.ftl
+++ b/Resources/Locale/ru-RU/Imperial/entities/supermatter.ftl
@@ -30,3 +30,6 @@ supermatter-monitor-next-event = Следующий импульс через: {
     [few] {$minutes} минуты
     *[other] {$minutes} минут
 }
+
+supermatter-station-catastrophe = Внимание! Станция подвергается катастрофе суперматерии! Немедленно эвакуируйтесь и удалите персонал от кристалла!
+supermatter-catastrophe-warning = Внимание: Суперматерия теряет стабильность! Требуется срочная стабилизация!

--- a/Resources/Prototypes/Imperial/Entities/Structures/Power/Generation/SuperMatter/crystal.yml
+++ b/Resources/Prototypes/Imperial/Entities/Structures/Power/Generation/SuperMatter/crystal.yml
@@ -56,6 +56,9 @@
     - type: Damageable
       damageContainer: Structural
     - type: SupermatterIntegrity
+      tickDamage:
+        types:
+          Blunt: 0.65
     - type: SupermatterEvent
     - type: GuideHelp
       guides:

--- a/Resources/Prototypes/Imperial/Entities/Structures/Power/Generation/SuperMatter/supermatter_explosion.yml
+++ b/Resources/Prototypes/Imperial/Entities/Structures/Power/Generation/SuperMatter/supermatter_explosion.yml
@@ -1,0 +1,20 @@
+- type: explosion
+  id: Supermatter
+  name: supermatter blast
+  description: A dazzling but destructive release of supermatter energy.
+  damagePerIntensity:
+    types:
+      Radiation: 6
+      Heat: 6
+      Blunt: 4
+      Structural: 12
+  tileBreakChance: [0, 0.6, 1]
+  tileBreakIntensity: [0, 20, 50]
+  tileBreakRerollReduction: 15
+  intensityPerState: 40
+  intensityPerStateVariation: 8
+  lightColor: Yellow
+  fireColor: Yellow
+  texturePath: /Textures/Effects/fire_greyscale.rsi
+  fireStates: 4
+  fireStacks: 2


### PR DESCRIPTION
(cherry picked from commit 81f9d7e3fa9d45055f22dffd573fba37f46cd68e)

## О ПР`е
Хотфикс суперматерии

## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->

## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Новые возможности
  - Автопереход станции на жёлтый уровень тревоги при критической нестабильности суперматерии с общестанционным объявлением.
  - Консоль мониторинга показывает состояние по наивысшему достигнутому порогу; луч активируется только на максимальном уровне.
  - Добавлена уникальная конфигурация взрыва суперматерии.

- Исправления ошибок
  - Повышена точность расчёта целостности, корректно сбрасываются предупреждения и пороги.
  - Урон по кристаллу применяется только при опасных условиях и обрабатывается равномерными тиками.

- Документация
  - Добавлены русские сообщения-предупреждения о катастрофе суперматерии.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->