### PR TITLE
fix: локализация информации о раунде

### DIFF
--- a/Resources/Locale/ru-RU/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/ru-RU/game-ticking/game-ticker.ftl
@@ -33,7 +33,7 @@ player-first-join-message = Игрок {$name} зашёл впервые!
 # Displayed in chat to admins when a player leaves
 player-leave-message = Игрок {$name} вышел.
 
-latejoin-arrival-announcement = {$character} ({$job}) прибыл на станцию!
+latejoin-arrival-announcement = {$character}, {$job}, прибыл на станцию!
 latejoin-arrival-announcement-special = {$job} {$character} на борту!
 latejoin-arrival-sender = Общее
 latejoin-arrivals-direction = Вскоре прибудет шаттл, который доставит вас на станцию.

--- a/Resources/Locale/ru-RU/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/ru-RU/game-ticking/game-ticker.ftl
@@ -8,12 +8,12 @@ game-ticker-delay-start = Начало раунда было отложено н
 game-ticker-pause-start = Начало раунда было приостановлено.
 game-ticker-pause-start-resumed = Отсчет начала раунда возобновлен.
 game-ticker-player-join-game-message = Добро пожаловать на Космическую Станцию 14! Если вы играете впервые, обязательно нажмите ESC на клавиатуре и прочитайте правила игры, а также не бойтесь просить помощи в LOOC чате или "Админ помощь".
-game-ticker-get-info-text = Привет и добро пожаловать в [color=white]Space Station 14![/color]
-                            Текущий раунд: [color=white]#{ $roundId }[/color]
-                            Текущее количество игроков: [color=white]{ $playerCount }[/color]
+game-ticker-get-info-text = Привет и добро пожаловать на [color=white]Космическую Станцию 14![/color]
+                            Текущий раунд: [color=white]#{$roundId}[/color]
+                            Текущее количество игроков: [color=white]{$playerCount}[/color]
                             Текущая карта: [color=white]{$mapName}[/color]
                             Текущий режим игры: [color=white]{$gmTitle}[/color]
-                            >[color=yellow]{ $desc }[/color]
+                            >[color=yellow]{$desc}[/color]
 game-ticker-get-info-preround-text = Привет и добро пожаловать на [color=white]Космическую Станцию 14![/color]
                             Текущий раунд: [color=white]#{$roundId}[/color]
                             Текущее количество игроков: [color=white]{$playerCount}[/color] ([color=white]{$readyCount}[/color] {$readyCount ->
@@ -34,12 +34,16 @@ player-first-join-message = Игрок {$name} зашёл впервые!
 player-leave-message = Игрок {$name} вышел.
 
 latejoin-arrival-announcement = {$character} ({$job}) прибыл на станцию!
+latejoin-arrival-announcement-special = {$job} {$character} на борту!
 latejoin-arrival-sender = Общее
 latejoin-arrivals-direction = Вскоре прибудет шаттл, который доставит вас на станцию.
 latejoin-arrivals-direction-time = Шаттл, который доставит вас на станцию, прибудет через {$time}.
-game-run-level-PreRoundLobby = Лобби до начала раунда
-game-run-level-PostRound = После раунда
-game-run-level-InRound = В раунде
 latejoin-arrivals-dumped-from-shuttle = Таинственная сила не позволяет вам улететь на шаттле прибытия.
 latejoin-arrivals-teleport-to-spawn = Таинственная сила телепортирует вас с шаттла прибытия. Удачной смены!
-latejoin-arrival-announcement-special = {$job} {$character} на борту!
+
+preset-not-enough-ready-players = Невозможно запустить игровой режим {$presetName}. Требуется {$minimumPlayers} готовых игроков, сейчас: {$readyPlayersCount}.
+preset-no-one-ready = Невозможно запустить игровой режим {$presetName}. Нет готовых игроков.
+
+game-run-level-PreRoundLobby = Лобби до начала раунда
+game-run-level-InRound = В раунде
+game-run-level-PostRound = После раунда

--- a/Resources/Locale/ru-RU/preset.ftl
+++ b/Resources/Locale/ru-RU/preset.ftl
@@ -1,2 +1,0 @@
-preset-not-enough-ready-players = недостаточно готовых игроков
-preset-no-one-ready = никто не готов


### PR DESCRIPTION
## О ПР`е
<!-- Эта информация попадет в чейнджлог, пожалуйста, заполните ее -->

<!--
    Тип изменения, может быть одним из следующих:
    - feat
    - tweak
    - fix
    - remove

    Ставьте feat, если вы что-то добавили.
    Ставьте tweak, если вы изменили баланс или механику.
    Ставьте fix, если это исправление чего-то.
    Ставьте remove, если вы что-то удалили или ревертнули

    Если вы добавляете/изменяете/удаляете ивентовый контент, то всегда ставьте feat
-->
Тип: fix
<!--
    Что вы изменили?
    Пишите от третьего лица, кратко.
    Не переносите текст на следующую строку.
    Пример: "Урон от туллбокса был увеличен в два раза"

    Если вы добавляете/изменяете/удаляете ивентовый контент, то всегда пишите "Ивентовый контент"
-->
Изменения: Исправлена локализация названия игры в лобби

<!--
    Пример правильного заполнения:

    Тип: tweak
    Изменения: Урон от туллбокса был увеличен в два раза
-->

## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->

Мне не нравилось что до начала раунда в лобби пишется "на Космическую Станцию 14", а после - "в Space Station 14".

Также, отсортировал и добавил недостающие строки как в английском файле.

Почему-то две строки находились в каком-то рандомном файле, перенёс в правильный.

Проведя малюсенькое собственное исследование, а затем спросив у трёх LLM, решил изменить объявление о прибытии на станцию на более логичное, так как в русском языке чаще всего используют обособление запятыми для указания профессии, если затем идёт действие.

## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->

*Нет*
