### PR TITLE
BORG MODULE EMERGENCY FIX

### DIFF
--- a/Resources/Prototypes/Imperial/SyndieBorg/SyndieModules/modules.yml
+++ b/Resources/Prototypes/Imperial/SyndieBorg/SyndieModules/modules.yml
@@ -47,10 +47,36 @@
       hands:
         - item: SyndiBorgEpinephrineInjector
         - item: HandheldHealthAnalyzerUnpowered
-        - item: Gauze10Lingering
-        - item: Brutepack10Lingering
-        - item: Ointment10Lingering
-        - item: Bloodpack10Lingering
+        - item: DefibrillatorSyndicateAgentCyborg
+        - item: Gauze
+          hand:
+            emptyLabel: borg-slot-topicals-empty
+            emptyRepresentative: Gauze
+            whitelist:
+              components:
+              - Healing
+        - item: Brutepack
+          hand:
+            emptyLabel: borg-slot-topicals-empty
+            emptyRepresentative: Brutepack
+            whitelist:
+              components:
+              - Healing
+        - item: Ointment
+          hand:
+            emptyLabel: borg-slot-topicals-empty
+            emptyRepresentative: Ointment
+            whitelist:
+              components:
+              - Healing
+        - item: Bloodpack
+          hand:
+            emptyLabel: borg-slot-topicals-empty
+            emptyRepresentative: Bloodpack
+            whitelist:
+              components:
+              - Healing
+  - type: BorgModuleIcon
         - item: DefibrillatorSyndicateAgentCyborg
     - type: BorgModuleIcon
       icon: { sprite: Imperial/SyndieBorg/interface.rsi, state: guardian-angel-module }


### PR DESCRIPTION
## О ПР`е
Тип: tweak

Изменения: срочный фикс модуля "Ангел-Хранитель" для аплинк-боргов. С приходом апстрима он сломался.

## Технические детали
- Измненено Resources/Prototypes/Imperial/SyndieBorg/SyndieModules/modules.yml

## Объяснительная

Модуль делался на сборке, актуальной ДО апстрима. Залит же он был ВМЕСТЕ с апстримом, отчего я чисто физически все поправить не мог. Неприятный казус, но попрошу и меня понять. Админам посоветуйте бвонькать за дюп предметов через модуль, а игрокам воздержаться от покупки до фикса.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Новые возможности
  * Модуль «Guardian Angel» у синдикатного киборга получил дефибриллятор для экстренной реанимации.
  * Обновлён набор медицинских средств: стандартные бинты, брут‑пак, мазь и пакет крови, обеспечивающие надёжное лечение.
  * Улучшена организация слотов для топиков: понятные подписи пустых ячеек и корректная работа с лечащими предметами для быстрого доступа и использования.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->