### PR TITLE
фикс фикса

### DIFF
--- a/Resources/Prototypes/Imperial/SyndieBorg/SyndieModules/modules.yml
+++ b/Resources/Prototypes/Imperial/SyndieBorg/SyndieModules/modules.yml
@@ -76,8 +76,6 @@
             whitelist:
               components:
               - Healing
-  - type: BorgModuleIcon
-        - item: DefibrillatorSyndicateAgentCyborg
     - type: BorgModuleIcon
       icon: { sprite: Imperial/SyndieBorg/interface.rsi, state: guardian-angel-module }
 


### PR DESCRIPTION
## О ПР`е 
Тип: tweaк: 

Изменения: вчера я был п-дец сонный и наляпал нерабочий фикс за пару минуток на нервах. Извиняюсь, вот рабочая версия. Теперь модули синдиката работают исправно.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Исправления ошибок
  - Устранено дублирование записи иконки модуля, некорректно связанной с дефибриллятором в модуле «Guardian Angel» у синдикатного киборга. Это предотвращает появление лишней иконки/опции при выборе модулей и снижает путаницу в интерфейсе.
  - Прочие иконки и записи модулей оставлены без изменений.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->