### PR TITLE
Фикс разрывных патронов

### DIFF
--- a/Content.Server/Imperial/ExplosiveProjectile/ExplosiveProjectileSystem.ResultOn.cs
+++ b/Content.Server/Imperial/ExplosiveProjectile/ExplosiveProjectileSystem.ResultOn.cs
@@ -22,6 +22,7 @@ namespace Content.Server.Imperial.ExplosiveProjectile
         {
             _explosion.QueueExplosion(uid, ExplosionSystem.DefaultExplosionPrototypeId, 1, 1, 1);
             _body.GibBody(uid, splatModifier: 5f);
+            RemComp<ExplosiveProjectileResultOnComponent>(uid);
         }
         private void GetDelayTime(EntityUid uid, ExplosiveProjectileResultOnComponent component, ComponentStartup args)
         {

--- a/Content.Server/Imperial/ExplosiveProjectile/ExplosiveProjectileSystem.cs
+++ b/Content.Server/Imperial/ExplosiveProjectile/ExplosiveProjectileSystem.cs
@@ -41,11 +41,13 @@ namespace Content.Server.Imperial.ExplosiveProjectile
             HasComp<PressureProtectionComponent>(clothingTarget))
             {
                 EnsureComp<ExplosiveProjectileResultOffComponent>(target);
+                Del(uid);
             }
             else
             {
                 if (HasComp<BodyComponent>(target))
                     EnsureComp<ExplosiveProjectileResultOnComponent>(target);
+                Del(uid);
             }
         }
         private void OnExplodeStart(EntityUid uid, ExplosiveProjectileComponent component, EntityUid target)


### PR DESCRIPTION
## О ПР`е
<!-- Эта информация попадет в чейнджлог, пожалуйста, заполните ее -->

Тип: fix
Изменения: Попадание разрывного патрона в сущность с годмодом больше не вызывает "фейерверк".

Тип: tweak 
Изменения: Теперь при коллизии разрывные патроны всегда удаляются.

## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->

*Нет*

## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->

*Нет*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Исправления ошибок

* Исправлена обработка взрывных снарядов после детонации. Снаряды теперь корректно удаляются из игровой среды независимо от типа пораженной цели или наличия защитного снаряжения. Это предотвращает накопление остаточных компонентов в памяти, значительно улучшает производительность системы и обеспечивает надлежащее управление ресурсами во время интенсивных боевых ситуаций.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->