### PR TITLE
Суперматерия не получает обычного урона, катастрофу можно отключить через ViewVariables

### DIFF
--- a/Content.Server/Imperial/Power/Components/SupermatterIntegrityComponent.cs
+++ b/Content.Server/Imperial/Power/Components/SupermatterIntegrityComponent.cs
@@ -96,6 +96,7 @@ public sealed partial class SupermatterIntegrityComponent : Component
     /// <summary>
     /// Активна ли катастрофа
     /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
     public bool CatastropheActive = false;
 
     /// <summary>

--- a/Resources/Prototypes/Imperial/Entities/Structures/Power/Generation/SuperMatter/crystal.yml
+++ b/Resources/Prototypes/Imperial/Entities/Structures/Power/Generation/SuperMatter/crystal.yml
@@ -55,8 +55,6 @@
       follow: true
       location: supermatter
     - type: SupermatterTouch
-    - type: Damageable
-      damageContainer: StructuralInorganic
     - type: SupermatterIntegrity
       tickDamage:
         types:


### PR DESCRIPTION
## О ПР`е
<!-- Эта информация попадет в чейнджлог, пожалуйста, заполните ее -->

<!--
    Тип изменения, может быть одним из следующих:
    - feat
    - tweak
    - fix
    - remove

    Ставьте feat, если вы что-то добавили.
    Ставьте tweak, если вы изменили баланс или механику.
    Ставьте fix, если это исправление чего-то.
    Ставьте remove, если вы что-то удалили или ревертнули

    Если вы добавляете/изменяете/удаляете ивентовый контент, то всегда ставьте feat
-->
Тип: tweak
<!--
    Что вы изменили?
    Пишите от третьего лица, кратко.
    Не переносите текст на следующую строку.
    Пример: "Урон от туллбокса был увеличен в два раза"

    Если вы добавляете/изменяете/удаляете ивентовый контент, то всегда пишите "Ивентовый контент"
-->
Изменения: Суперматерия теперь не получает обычного урона

<!--
    Пример правильного заполнения:

    Тип: tweak
    Изменения: Урон от туллбокса был увеличен в два раза
-->

## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->

Было доложено что суперматерию можно сломать чем угодно, вот и исправил

## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->

*Нет*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Изменения

* **Балансовые изменения**
  * Изменено поведение кристалла супермассы при взаимодействии с повреждениями.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->