### PR TITLE
Фикс хирургического модуля борга ОБР

### DIFF
--- a/Resources/Prototypes/Imperial/Roles/Jobs/Synthetics/ImperialBorgModules.yml
+++ b/Resources/Prototypes/Imperial/Roles/Jobs/Synthetics/ImperialBorgModules.yml
@@ -933,6 +933,7 @@
           - MedicalBorgItem
           - OxygenMask
           - GasTank
+          - Trash
     - item: SurgeryBoxOrgansFilled
       hand:
         emptyLabel: borg-slot-topicals-empty
@@ -940,9 +941,11 @@
         whitelist:
           tags:
           - OriginalBodyPart
+          - MedicalBorgItem
           - Organ
           - BodyPart
-          - Storage
+          - BoxCardboard
+          - Trash
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: diagnosis-module }
   - type: StaticPrice

--- a/Resources/Prototypes/Imperial/Roles/Jobs/Synthetics/borgdrobe_ert/store.yml
+++ b/Resources/Prototypes/Imperial/Roles/Jobs/Synthetics/borgdrobe_ert/store.yml
@@ -333,7 +333,7 @@
   productEntity: MechEquipmentTeslaEnergyRelay
   priority: 28
   cost:
-    BlueSpaceCube: 8
+    BlueSpaceCube: 6
   categories:
   - ErtBorgDrobeMech
 


### PR DESCRIPTION
## О ПР`е
<!-- Эта информация попадет в чейнджлог, пожалуйста, заполните ее -->

Тип: fix

Изменения: Медицинский киборг ОБР теперь может брать в руки коробки (для ношения коробки с органами), и части тела.
## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->

- Изменён прототип хирургического модуля.
## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->

*Нет*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Исправления и улучшения

* **Bug Fixes**
  * Расширено взаимодействие синтетических модулей с объектами в среде (добавлены дополнительные теги разрешённых предметов для модулей Borg).
* **Chores**
  * Снижена стоимость предмета MechEquipmentTeslaEnergyRelay в магазине (цена уменьшена с 8 до 6).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->