### PR TITLE
Фаерболл требует мантию

### DIFF
--- a/Resources/Prototypes/Magic/projectile_spells.yml
+++ b/Resources/Prototypes/Magic/projectile_spells.yml
@@ -5,6 +5,7 @@
   description: Fires an explosive fireball towards the clicked location.
   components:
   - type: Magic
+    requiresClothes: true ### Imperial Mage Rework
   - type: Action
     useDelay: 15
     itemIconStyle: BigAction


### PR DESCRIPTION
## О ПР`е
Тип: tweak
Изменения: Теперь заклинание фаерболла требует робу мага

Теперь фаерболл требует робу мага. С самого добавления свитка ТП у мага существует мета манча скафа РД с 90% резистом ко взрыву и дальнейшему тупому кастованию фаеров в лицо. Такое изменение сделает мага более вариативным и сложным, в целом позитивно сказываясь на разнообразии раундов.

Это так же сократит количество ранних эваков при обнаружении краденного скафандра и всеубивающего мага.

## Изменения кода официальных разработчиков
* Update projectile_spells.yml


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Новые возможности**
  * Добавлено требование экипировки одежды для некоторых магических способностей персонажа класса Imperial Mage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->