### PR TITLE
Таймер для покупки военного рига

### DIFF
--- a/Resources/Prototypes/Imperial/Other/Modsuits/misc.yml
+++ b/Resources/Prototypes/Imperial/Other/Modsuits/misc.yml
@@ -27,6 +27,7 @@
       blacklist:
         tags:
           - NukeOpsUplink
+  restockTime: 1800
 
 - type: listing
   id: ModsuitNukeOperativeSealed


### PR DESCRIPTION
## О ПР`е
<!-- Эта информация попадет в чейнджлог, пожалуйста, заполните ее -->

<!--
    Тип изменения, может быть одним из следующих:
    - feat
    - tweak
    - fix
    - remove

    Ставьте feat, если вы что-то добавили.
    Ставьте tweak, если вы изменили баланс или механику.
    Ставьте fix, если это исправление чего-то.
    Ставьте remove, если вы что-то удалили или ревертнули

    Если вы добавляете/изменяете/удаляете ивентовый контент, то всегда ставьте feat
-->
Тип:    - tweak
<!--
    Что вы изменили?
    Пишите от третьего лица, кратко.
    Не переносите текст на следующую строку.
    Пример: "Урон от туллбокса был увеличен в два раза"

    Если вы добавляете/изменяете/удаляете ивентовый контент, то всегда пишите "Ивентовый контент"
-->
Изменения: Добавлен таймер на покупку военного рига

Этот пр нужен для предотвращения появления военного рига более чем у одного ядерного оперативника/агента каждые полчаса.

Имхо, это лучшая доступная игрокам броня, с рапирой, ампулами с трайметом, можно вырезать всю станцию и не вспотеть. Представьте что происходит когда таких людей в военных ригах больше одного.
<!--
    Пример правильного заполнения:

    Тип: tweak
    Изменения: Урон от туллбокса был увеличен в два раза
-->

## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->

*Нет*

## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->

*Нет*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Исправления ошибок

* Добавлен таймер перезагрузки запасов для специального экипирования, устанавливающий 30-минутный интервал перед повторной доступностью элемента.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->