### PR TITLE
Crawling for legs paralyzed

### DIFF
--- a/Content.Server/Imperial/Traits/ImperialLegsParalyzedSystem.cs
+++ b/Content.Server/Imperial/Traits/ImperialLegsParalyzedSystem.cs
@@ -1,0 +1,7 @@
+using Content.Shared.Imperial.Traits;
+
+namespace Content.Server.Imperial.Traits;
+
+public sealed class ImperialLegsParalyzedSystem : SharedImperialLegsParalyzedSystem
+{
+}

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -23,6 +23,7 @@ using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Humanoid;
 using Content.Shared.Interaction.Components;
+using Content.Shared.Imperial.Traits;  //Imperial "CrawlingForLegsParalyzed"
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Pulling.Components;
@@ -141,6 +142,7 @@ public sealed partial class ZombieSystem
         RemComp<ReproductiveComponent>(target);
         RemComp<ReproductivePartnerComponent>(target);
         RemComp<LegsParalyzedComponent>(target);
+        RemComp<ImperialLegsParalyzedComponent>(target); //Imperial "CrawlingForLegsParalyzed"
         RemComp<ComplexInteractionComponent>(target);
         RemComp<SentienceTargetComponent>(target);
 

--- a/Content.Shared/Imperial/ImperialVehicle/SharedImperialVehicleSystem.cs
+++ b/Content.Shared/Imperial/ImperialVehicle/SharedImperialVehicleSystem.cs
@@ -59,8 +59,6 @@ public abstract partial class SharedImperialVehicleSystem : EntitySystem
         SubscribeLocalEvent<ImperialVehiclePilotComponent, MoveEvent>(OnPilotMove);
         SubscribeLocalEvent<ImperialVehiclePilotComponent, ContainerGettingInsertedAttemptEvent>(OnPilotInsertAttempt);
         SubscribeLocalEvent<ImperialVehiclePilotComponent, ContainerIsInsertingAttemptEvent>(OnPilotInsertingAttempt);
-
-        SubscribeLocalEvent<LegsParalyzedComponent, DownedEvent>(OnLegsParalyzedDowned);
     }
 
     public override void Update(float frameTime)
@@ -381,18 +379,6 @@ public abstract partial class SharedImperialVehicleSystem : EntitySystem
                 : (int)DrawDepth.DrawDepth.WallMountedItems,
             _ => (int)DrawDepth.DrawDepth.WallMountedItems
         };
-    }
-
-    /// <summary>
-    /// Sets crawl movement speed for paralyzed entities when they are downed.
-    /// </summary>
-    private void OnLegsParalyzedDowned(EntityUid uid, LegsParalyzedComponent component, DownedEvent args)
-    {
-        _modifier.ChangeBaseSpeed(
-            uid,
-            component.CrawlMoveSpeed,
-            component.CrawlMoveSpeed,
-            component.CrawlMoveAcceleration);
     }
 
     /// <summary>

--- a/Content.Shared/Imperial/Traits/ImperialLegsParalyzedComponent.cs
+++ b/Content.Shared/Imperial/Traits/ImperialLegsParalyzedComponent.cs
@@ -15,10 +15,7 @@ public sealed partial class ImperialLegsParalyzedComponent : Component
     public bool AddedKnockdown = false;
 
     [DataField, ViewVariables]
-    public float CrawlWalkSpeed = 0.9f;
-
-    [DataField, ViewVariables]
-    public float CrawlSprintSpeed = 0.9f;
+    public float CrawlSpeed = 0.9f;
 
     [DataField, ViewVariables]
     public float CrawlAcceleration = 25f;

--- a/Content.Shared/Imperial/Traits/ImperialLegsParalyzedComponent.cs
+++ b/Content.Shared/Imperial/Traits/ImperialLegsParalyzedComponent.cs
@@ -1,0 +1,25 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Imperial.Traits;
+
+/// <summary>
+/// A disabled person can crawl slowly because he has arms!
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(SharedImperialLegsParalyzedSystem))]
+public sealed partial class ImperialLegsParalyzedComponent : Component
+{
+    /// <summary>
+    /// Tracks whether added a crawl state
+    /// </summary>
+    [DataField, ViewVariables]
+    public bool AddedKnockdown = false;
+
+    [DataField, ViewVariables]
+    public float CrawlWalkSpeed = 0.9f;
+
+    [DataField, ViewVariables]
+    public float CrawlSprintSpeed = 0.9f;
+
+    [DataField, ViewVariables]
+    public float CrawlAcceleration = 25f;
+}

--- a/Content.Shared/Imperial/Traits/SharedImperialLegsParalyzedSystem.cs
+++ b/Content.Shared/Imperial/Traits/SharedImperialLegsParalyzedSystem.cs
@@ -23,15 +23,15 @@ public abstract partial class SharedImperialLegsParalyzedSystem : EntitySystem
 
     private void OnStartup(EntityUid uid, ImperialLegsParalyzedComponent component, ComponentStartup args)
     {
-        _stun.TryCrawling(uid, autoStand: false);
         _movementSpeedModifierSystem.ChangeBaseSpeed(
             uid,
-            component.CrawlWalkSpeed,
-            component.CrawlSprintSpeed,
+            component.CrawlSpeed,
+            component.CrawlSpeed,
             component.CrawlAcceleration
         );
 
-        component.AddedKnockdown = true;
+        if (_stun.TryCrawling(uid, autoStand: false))
+            component.AddedKnockdown = true;
     }
 
     private void OnShutdown(EntityUid uid, ImperialLegsParalyzedComponent component, ComponentShutdown args)
@@ -56,8 +56,8 @@ public abstract partial class SharedImperialLegsParalyzedSystem : EntitySystem
         {
             _movementSpeedModifierSystem.ChangeBaseSpeed(
                 uid,
-                component.CrawlWalkSpeed,
-                component.CrawlSprintSpeed,
+                component.CrawlSpeed,
+                component.CrawlSpeed,
                 component.CrawlAcceleration
             );
         }

--- a/Content.Shared/Imperial/Traits/SharedImperialLegsParalyzedSystem.cs
+++ b/Content.Shared/Imperial/Traits/SharedImperialLegsParalyzedSystem.cs
@@ -23,15 +23,13 @@ public abstract partial class SharedImperialLegsParalyzedSystem : EntitySystem
 
     private void OnStartup(EntityUid uid, ImperialLegsParalyzedComponent component, ComponentStartup args)
     {
+        component.AddedKnockdown = _stun.TryCrawling(uid, autoStand: false);
         _movementSpeedModifierSystem.ChangeBaseSpeed(
             uid,
             component.CrawlSpeed,
             component.CrawlSpeed,
             component.CrawlAcceleration
         );
-
-        if (_stun.TryCrawling(uid, autoStand: false))
-            component.AddedKnockdown = true;
     }
 
     private void OnShutdown(EntityUid uid, ImperialLegsParalyzedComponent component, ComponentShutdown args)

--- a/Content.Shared/Imperial/Traits/SharedImperialLegsParalyzedSystem.cs
+++ b/Content.Shared/Imperial/Traits/SharedImperialLegsParalyzedSystem.cs
@@ -1,0 +1,75 @@
+using Content.Shared.Body.Systems;
+using Content.Shared.Gravity;
+using Content.Shared.Movement.Systems;
+using Content.Shared.Standing;
+using Content.Shared.Stunnable;
+
+namespace Content.Shared.Imperial.Traits;
+
+public abstract partial class SharedImperialLegsParalyzedSystem : EntitySystem
+{
+    [Dependency] private readonly MovementSpeedModifierSystem _movementSpeedModifierSystem = default!;
+    [Dependency] private readonly StandingStateSystem _standingState = default!;
+    [Dependency] private readonly SharedBodySystem _bodySystem = default!;
+    [Dependency] private readonly SharedStunSystem _stun = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ImperialLegsParalyzedComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<ImperialLegsParalyzedComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<ImperialLegsParalyzedComponent, StandUpAttemptEvent>(OnStandUpAttempt);
+        SubscribeLocalEvent<ImperialLegsParalyzedComponent, WeightlessnessChangedEvent>(OnWeightlessnessChanged);
+    }
+
+    private void OnStartup(EntityUid uid, ImperialLegsParalyzedComponent component, ComponentStartup args)
+    {
+        _stun.TryCrawling(uid, autoStand: false);
+        _movementSpeedModifierSystem.ChangeBaseSpeed(
+            uid,
+            component.CrawlWalkSpeed,
+            component.CrawlSprintSpeed,
+            component.CrawlAcceleration
+        );
+
+        component.AddedKnockdown = true;
+    }
+
+    private void OnShutdown(EntityUid uid, ImperialLegsParalyzedComponent component, ComponentShutdown args)
+    {
+        if (component.AddedKnockdown && TryComp<KnockedDownComponent>(uid, out var knockedDown))
+        {
+            _stun.CancelKnockdownDoAfter((uid, knockedDown));
+            RemComp<KnockedDownComponent>(uid);
+        }
+
+        _bodySystem.UpdateMovementSpeed(uid);
+    }
+
+    private void OnWeightlessnessChanged(EntityUid uid, ImperialLegsParalyzedComponent component, WeightlessnessChangedEvent args)
+    {
+        if (args.Weightless)
+        {
+            _bodySystem.UpdateMovementSpeed(uid);
+            _standingState.Down(uid);
+        }
+        else
+        {
+            _movementSpeedModifierSystem.ChangeBaseSpeed(
+                uid,
+                component.CrawlWalkSpeed,
+                component.CrawlSprintSpeed,
+                component.CrawlAcceleration
+            );
+        }
+    }
+
+    private void OnStandUpAttempt(EntityUid uid, ImperialLegsParalyzedComponent component, ref StandUpAttemptEvent args)
+    {
+        args.Cancelled = true;
+
+        if (TryComp<KnockedDownComponent>(uid, out var knockedDown))
+        {
+            _stun.SetAutoStand((uid, knockedDown), false);
+        }
+    }
+}

--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -7,6 +7,7 @@ using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.Gravity;
 using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Imperial.Traits; // Imperial "CrawlingForLegsParalyzed"
 using Content.Shared.Input;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
@@ -275,6 +276,9 @@ public abstract partial class SharedStunSystem
             _adminLogger.Add(LogType.Stamina, LogImpact.Medium, $"{ToPrettyString(entity):user} has stood up from knockdown.");
             return true;
         }
+
+        if (HasComp<ImperialLegsParalyzedComponent>(entity)) // Imperial "CrawlingForLegsParalyzed"
+            return false; // Imperial "CrawlingForLegsParalyzed"
 
         if (!TryStand((entity, entity.Comp)))
             return false;

--- a/Content.Shared/Traits/Assorted/LegsParalyzedComponent.cs
+++ b/Content.Shared/Traits/Assorted/LegsParalyzedComponent.cs
@@ -8,6 +8,4 @@ namespace Content.Shared.Traits.Assorted;
 [RegisterComponent, NetworkedComponent, Access(typeof(LegsParalyzedSystem))]
 public sealed partial class LegsParalyzedComponent : Component
 {
-    [DataField] public float CrawlMoveSpeed = 0; // Imperial "ImperialVehicle"
-    [DataField] public float CrawlMoveAcceleration = 0; // Imperial "ImperialVehicle"
 }

--- a/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
+++ b/Content.Shared/Traits/Assorted/LegsParalyzedSystem.cs
@@ -20,7 +20,7 @@ public sealed class LegsParalyzedSystem : EntitySystem
         SubscribeLocalEvent<LegsParalyzedComponent, BuckledEvent>(OnBuckled);
         SubscribeLocalEvent<LegsParalyzedComponent, UnbuckledEvent>(OnUnbuckled);
         SubscribeLocalEvent<LegsParalyzedComponent, ThrowPushbackAttemptEvent>(OnThrowPushbackAttempt);
-        SubscribeLocalEvent<LegsParalyzedComponent, StandAttemptEvent>(OnStandTry); // Imperial "ImperialVehicle"
+        SubscribeLocalEvent<LegsParalyzedComponent, UpdateCanMoveEvent>(OnUpdateCanMoveEvent);
     }
 
     private void OnStartup(EntityUid uid, LegsParalyzedComponent component, ComponentStartup args)
@@ -38,11 +38,6 @@ public sealed class LegsParalyzedSystem : EntitySystem
     private void OnBuckled(EntityUid uid, LegsParalyzedComponent component, ref BuckledEvent args)
     {
         _standingSystem.Stand(uid);
-        _movementSpeedModifierSystem.ChangeBaseSpeed( // Imperial "ImperialVehicle" Start
-            uid,
-            component.CrawlMoveSpeed,
-            component.CrawlMoveSpeed,
-            component.CrawlMoveAcceleration); // Imperial "ImperialVehicle" End
     }
 
     private void OnUnbuckled(EntityUid uid, LegsParalyzedComponent component, ref UnbuckledEvent args)
@@ -50,10 +45,9 @@ public sealed class LegsParalyzedSystem : EntitySystem
         _standingSystem.Down(uid);
     }
 
-    private void OnStandTry(EntityUid uid, LegsParalyzedComponent component, StandAttemptEvent args) // Imperial "ImperialVehicle"
+    private void OnUpdateCanMoveEvent(EntityUid uid, LegsParalyzedComponent component, UpdateCanMoveEvent args)
     {
         args.Cancel();
-        _standingSystem.Down(uid); // Imperial "ImperialVehicle"
     }
 
     private void OnThrowPushbackAttempt(EntityUid uid, LegsParalyzedComponent component, ThrowPushbackAttemptEvent args)

--- a/Resources/Prototypes/Imperial/Objects/Specific/Vehicles/ImperialWheelchair/misc.yml
+++ b/Resources/Prototypes/Imperial/Objects/Specific/Vehicles/ImperialWheelchair/misc.yml
@@ -22,7 +22,7 @@
   components:
     - type: BuckleOnMapInit
       prototype: ImperialVehicleWheelchair
-    - type: LegsParalyzed
+    - type: ImperialLegsParalyzed
 
 
 - type: entity


### PR DESCRIPTION
## О ПР`е
    Тип: tweak
    Изменения: Инвалиды теперь умеют ползать и летать в невесомости.

## Технические детали

Заменил обычный LegsParalyzed на созданный ImperialLegsParalyzed в прототипе черты инвалида.

## Изменения кода официальных разработчиков
Убрал изменения Империала в LegsParalyzed системе и компонента. 

Добавил проверку HasComp в метод SharedStunSystem.TryStanding, так как по-другому нельзя избавиться от визуального бага с доафтером. Баг был таким: при нажатии на выход из состояния лёжа появлялся DoAfter (TryStandDoAfterEvent), который останавливался на половине и не исчезал. Возникал, когда я блокировал действие в ивенте StandAttemptEvent, который вызывает TryStanding или TryStand. По-другому не смог решить. 

Добавил ещё удаление компонента **имперского** инвалида в ZombieSystem.Transform при заражении, ведь чёт не круто быть инвалидом-зомби (там удался визардский компонент инвалида, я решил и этот добавить ещё).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые функции**
  * Добавлена специализированная система паралича ног для имперских персонажей с параметрами ползания и обработкой падений.

* **Улучшения**
  * Блокировка попыток встать при имперском параличе ног.
  * Скорость и поведение передвижения при параличе пересмотрены и упрощены.
  * Имперская инвалидная коляска обновлена для совместимости с новой системой.

* **Исправления**
  * При превращении в зомби корректно снимается имперский эффект паралича ног.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->