### PR TITLE
Снижение стамин урона у энерго-болы до 0. в сбтех добавление +1 энерго-болы 

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -20,7 +20,7 @@
     RiotLaserShield: 2
     RiotBulletShield: 2
     RadioHandheldSecurity: 5
-    EnergyBola: 2 # Imperial Space EnergyBola
+    EnergyBola: 3 # Imperial Space EnergyBola
   # security officers need to follow a diet regimen!
   contrabandInventory:
     WeaponMeleeNeedle: 2

--- a/Resources/Prototypes/Imperial/Objects/Weapons/Throwable/EnergyBola/energy_bola.yml
+++ b/Resources/Prototypes/Imperial/Objects/Weapons/Throwable/EnergyBola/energy_bola.yml
@@ -41,6 +41,6 @@
     breakoutTime: 6
     walkSpeed: 0.5
     sprintSpeed: 0.5
-    staminaDamage: 70
+    staminaDamage: 0
     canThrowTrigger: true
     canMoveBreakout: true


### PR DESCRIPTION
## О ПР`е
Тип: tweak

Изменения: Снижение стамин урона у энерго-болы до 0. Было добавлено в сбтех +1 бола 

## Технические детали

*Нет*

## Изменения кода официальных разработчиков

*Нет*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Обновления

* **Балансировка игры**
  * Увеличено начальное количество энергетических болов в специальном инвентаре с 2 до 3 единиц.
  * Изменён урон выносливости энергетического бола с 70 до 0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->