### PR TITLE
Revert "Снижение стамин урона у энерго-болы до 0. в сбтех добавление +1 энерго-болы "

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -20,7 +20,7 @@
     RiotLaserShield: 2
     RiotBulletShield: 2
     RadioHandheldSecurity: 5
-    EnergyBola: 3 # Imperial Space EnergyBola
+    EnergyBola: 2 # Imperial Space EnergyBola
   # security officers need to follow a diet regimen!
   contrabandInventory:
     WeaponMeleeNeedle: 2

--- a/Resources/Prototypes/Imperial/Objects/Weapons/Throwable/EnergyBola/energy_bola.yml
+++ b/Resources/Prototypes/Imperial/Objects/Weapons/Throwable/EnergyBola/energy_bola.yml
@@ -41,6 +41,6 @@
     breakoutTime: 6
     walkSpeed: 0.5
     sprintSpeed: 0.5
-    staminaDamage: 0
+    staminaDamage: 70
     canThrowTrigger: true
     canMoveBreakout: true


### PR DESCRIPTION
Reverts imperial-space/SS14-public#587

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Изменения

* **Баланс игры**
  * Energy Bola теперь наносит урон выносливости при захвате противника.
  * Количество Energy Bola в торговом автомате SecTech сокращено.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->