### PR TITLE
Энерго бола баланс

### DIFF
--- a/Resources/Prototypes/Imperial/Objects/Weapons/Throwable/EnergyBola/energy_bola.yml
+++ b/Resources/Prototypes/Imperial/Objects/Weapons/Throwable/EnergyBola/energy_bola.yml
@@ -38,9 +38,9 @@
         Blunt: 3
   - type: Ensnaring
     freeTime: 2.0
-    breakoutTime: 6
+    breakoutTime: 3.5
     walkSpeed: 0.5
     sprintSpeed: 0.5
-    staminaDamage: 70
+    staminaDamage: 30
     canThrowTrigger: true
     canMoveBreakout: true


### PR DESCRIPTION
## О ПР`е


Тип: tweak

Изменения: снижен стамин урон до 30 и время снимание энерго болы снижена до 3.5


## Технические детали


*Нет*

*Нет*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Balance Changes**
  * Energy Bola: Reduced breakout time and stamina damage output for better combat balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->