### PR TITLE
Имплант свободы теперь снимает болы

### DIFF
--- a/Content.Shared/Imperial/Trigger/Components/Effects/FreedomImplantbolaTriggerComponent.cs
+++ b/Content.Shared/Imperial/Trigger/Components/Effects/FreedomImplantbolaTriggerComponent.cs
@@ -7,4 +7,4 @@ namespace Content.Shared.Imperial.Trigger.Components.Effects;
 /// Помечает сущность как эффект триггера импланта свободы. при срабатывании снимает наручники и освобождает цель от всех опутывающих сущностей
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-public sealed partial class FreedomImplantbolaTriggerComponent : BaseXOnTriggerComponent;
+public sealed partial class FreedomImplantBolaTriggerComponent : BaseXOnTriggerComponent;

--- a/Content.Shared/Imperial/Trigger/Components/Effects/FreedomImplantbolaTriggerComponent.cs
+++ b/Content.Shared/Imperial/Trigger/Components/Effects/FreedomImplantbolaTriggerComponent.cs
@@ -1,3 +1,4 @@
+using Robust.Shared.Audio;
 using Content.Shared.Trigger.Components.Effects;
 using Robust.Shared.GameStates;
 
@@ -7,4 +8,11 @@ namespace Content.Shared.Imperial.Trigger.Components.Effects;
 /// Помечает сущность как эффект триггера импланта свободы. при срабатывании снимает наручники и освобождает цель от всех опутывающих сущностей
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-public sealed partial class FreedomImplantBolaTriggerComponent : BaseXOnTriggerComponent;
+public sealed partial class FreedomImplantBolaTriggerComponent : BaseXOnTriggerComponent
+{
+	/// <summary>
+	/// Звук при снятии болы.
+	/// </summary>
+	[DataField]
+	public SoundSpecifier BolaBreakSound = new SoundPathSpecifier("/Audio/Effects/snap.ogg");
+}

--- a/Content.Shared/Imperial/Trigger/Components/Effects/FreedomImplantbolaTriggerComponent.cs
+++ b/Content.Shared/Imperial/Trigger/Components/Effects/FreedomImplantbolaTriggerComponent.cs
@@ -1,0 +1,10 @@
+using Content.Shared.Trigger.Components.Effects;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Imperial.Trigger.Components.Effects;
+
+/// <summary>
+/// Помечает сущность как эффект триггера импланта свободы. при срабатывании снимает наручники и освобождает цель от всех опутывающих сущностей
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class FreedomImplantbolaTriggerComponent : BaseXOnTriggerComponent;

--- a/Content.Shared/Imperial/Trigger/Systems/FreedomImplantbolaTriggerSystem.cs
+++ b/Content.Shared/Imperial/Trigger/Systems/FreedomImplantbolaTriggerSystem.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+using Content.Shared.Ensnaring;
+using Content.Shared.Ensnaring.Components;
+using Content.Shared.Imperial.Trigger.Components.Effects;
+using Content.Shared.Trigger;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Network;
+
+namespace Content.Shared.Imperial.Trigger.Systems;
+
+/// <summary>
+/// Обрабатывает эффект триггера импланта свободы: снимает наручники и освобождает цель от опутывающих сущностей (болы и т.д.)
+/// </summary>
+public sealed class FreedomImplantOnTriggerSystem : XOnTriggerSystem<FreedomImplantbolaTriggerComponent>
+{
+    /// <summary> Звук при снятии болы </summary>
+    private static readonly SoundSpecifier BolaBreakSound = new SoundPathSpecifier("/Audio/Effects/snap.ogg");
+
+    [Dependency] private readonly SharedEnsnareableSystem _ensnareable = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly INetManager _net = default!;
+
+    /// <summary>
+    /// при срабатывании импланта свободы, снимает наручники и удаляет все опутывающие сущности с цели.
+    /// </summary>
+    protected override void OnTrigger(Entity<FreedomImplantbolaTriggerComponent> ent, EntityUid target, ref TriggerEvent args)
+    {
+        // Снятие опутывания влияет на скорость движения и может вызвать рассинхрон на клиенте.
+        if (_net.IsClient)
+            return;
+
+        var playedBreakSound = false;
+
+        // Освобождаем цель от всех опутывающих сущностей (болы и т.д.)
+        if (TryComp<EnsnareableComponent>(target, out var ensnareable))
+        {
+            var ensnares = ensnareable.Container.ContainedEntities.ToList();
+            foreach (var ensnareEntity in ensnares)
+            {
+                if (!TryComp<EnsnaringComponent>(ensnareEntity, out var ensnaring))
+                    continue;
+
+                _ensnareable.ForceFree(ensnareEntity, ensnaring);
+
+                // ForceFree отправляет событие снятия на опутывающую сущность. импланту также нужно отправить событие на цель, чтобы корректно снять штрафы к скорости движения.
+                var ev = new EnsnareRemoveEvent(ensnaring.WalkSpeed, ensnaring.SprintSpeed);
+                RaiseLocalEvent(target, ev);
+
+                playedBreakSound = true;
+
+                QueueDel(ensnareEntity);
+            }
+
+            // Обновляем визуальное состояние: цель больше не опутана
+            if (TryComp<AppearanceComponent>(target, out var appearance))
+            {
+                _appearance.SetData(target, EnsnareableVisuals.IsEnsnared, ensnareable.IsEnsnared, appearance);
+            }
+        }
+
+        // Воспроизводим звук разрыва у позиции цели, если было снято хотя бы одно опутывание
+        if (playedBreakSound)
+            _audio.PlayPvs(BolaBreakSound, target);
+
+        args.Handled = true;
+    }
+}

--- a/Content.Shared/Imperial/Trigger/Systems/FreedomImplantbolaTriggerSystem.cs
+++ b/Content.Shared/Imperial/Trigger/Systems/FreedomImplantbolaTriggerSystem.cs
@@ -12,7 +12,7 @@ namespace Content.Shared.Imperial.Trigger.Systems;
 /// <summary>
 /// Обрабатывает эффект триггера импланта свободы: снимает наручники и освобождает цель от опутывающих сущностей (болы и т.д.)
 /// </summary>
-public sealed class FreedomImplantOnTriggerSystem : XOnTriggerSystem<FreedomImplantbolaTriggerComponent>
+public sealed class FreedomImplantOnTriggerSystem : XOnTriggerSystem<FreedomImplantBolaTriggerComponent>
 {
     /// <summary> Звук при снятии болы </summary>
     private static readonly SoundSpecifier BolaBreakSound = new SoundPathSpecifier("/Audio/Effects/snap.ogg");
@@ -25,7 +25,7 @@ public sealed class FreedomImplantOnTriggerSystem : XOnTriggerSystem<FreedomImpl
     /// <summary>
     /// при срабатывании импланта свободы, снимает наручники и удаляет все опутывающие сущности с цели.
     /// </summary>
-    protected override void OnTrigger(Entity<FreedomImplantbolaTriggerComponent> ent, EntityUid target, ref TriggerEvent args)
+    protected override void OnTrigger(Entity<FreedomImplantBolaTriggerComponent> ent, EntityUid target, ref TriggerEvent args)
     {
         // Снятие опутывания влияет на скорость движения и может вызвать рассинхрон на клиенте.
         if (_net.IsClient)

--- a/Content.Shared/Imperial/Trigger/Systems/FreedomImplantbolaTriggerSystem.cs
+++ b/Content.Shared/Imperial/Trigger/Systems/FreedomImplantbolaTriggerSystem.cs
@@ -3,7 +3,6 @@ using Content.Shared.Ensnaring;
 using Content.Shared.Ensnaring.Components;
 using Content.Shared.Imperial.Trigger.Components.Effects;
 using Content.Shared.Trigger;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 
@@ -14,9 +13,6 @@ namespace Content.Shared.Imperial.Trigger.Systems;
 /// </summary>
 public sealed class FreedomImplantOnTriggerSystem : XOnTriggerSystem<FreedomImplantBolaTriggerComponent>
 {
-    /// <summary> Звук при снятии болы </summary>
-    private static readonly SoundSpecifier BolaBreakSound = new SoundPathSpecifier("/Audio/Effects/snap.ogg");
-
     [Dependency] private readonly SharedEnsnareableSystem _ensnareable = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
@@ -27,10 +23,6 @@ public sealed class FreedomImplantOnTriggerSystem : XOnTriggerSystem<FreedomImpl
     /// </summary>
     protected override void OnTrigger(Entity<FreedomImplantBolaTriggerComponent> ent, EntityUid target, ref TriggerEvent args)
     {
-        // Снятие опутывания влияет на скорость движения и может вызвать рассинхрон на клиенте.
-        if (_net.IsClient)
-            return;
-
         var playedBreakSound = false;
 
         // Освобождаем цель от всех опутывающих сущностей (болы и т.д.)
@@ -42,7 +34,12 @@ public sealed class FreedomImplantOnTriggerSystem : XOnTriggerSystem<FreedomImpl
                 if (!TryComp<EnsnaringComponent>(ensnareEntity, out var ensnaring))
                     continue;
 
+                var wasEnsnaredByTarget = ensnaring.Ensnared == target;
                 _ensnareable.ForceFree(ensnareEntity, ensnaring);
+
+                // Отправляем снятие штрафа скорости только если эта бола действительно держала текущую цель.
+                if (!wasEnsnaredByTarget)
+                    continue;
 
                 // ForceFree отправляет событие снятия на опутывающую сущность. импланту также нужно отправить событие на цель, чтобы корректно снять штрафы к скорости движения.
                 var ev = new EnsnareRemoveEvent(ensnaring.WalkSpeed, ensnaring.SprintSpeed);
@@ -61,8 +58,8 @@ public sealed class FreedomImplantOnTriggerSystem : XOnTriggerSystem<FreedomImpl
         }
 
         // Воспроизводим звук разрыва у позиции цели, если было снято хотя бы одно опутывание
-        if (playedBreakSound)
-            _audio.PlayPvs(BolaBreakSound, target);
+        if (playedBreakSound && _net.IsServer)
+            _audio.PlayPvs(ent.Comp.BolaBreakSound, target);
 
         args.Handled = true;
     }

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -147,7 +147,7 @@
   - type: TriggerOnActivateImplant
   - type: UncuffOnTrigger
     targetUser: true
-  - type: FreedomImplantbolaTrigger # Imperial start
+  - type: FreedomImplantBolaTrigger # Imperial start
     targetUser: true                # Imperial end
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -147,6 +147,8 @@
   - type: TriggerOnActivateImplant
   - type: UncuffOnTrigger
     targetUser: true
+  - type: FreedomImplantbolaTrigger # Imperial start
+    targetUser: true                # Imperial end
 
 - type: entity
   parent: BaseSubdermalImplant


### PR DESCRIPTION
## О ПР`е

Тип: feat,tweak

Изменения: Имплант свободы теперь снимает болы


## Технические детали


*Нет*

## Изменения кода официальных разработчиков


*Да *
 - type: FreedomImplantbolaTrigger
    targetUser: true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Имплантат «Свободы» получил дополнительный триггер‑эффект: при активации он автоматически разрывает наложенные на цель эффекты связывания (болы), освобождает захваченные сущности, обновляет визуальное состояние цели и воспроизводит звук разрыва. Звук разрыва настраиваемый; эффект работает в сетевой игре и применяется к целевому пользователю.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->