### PR TITLE
Add GhostComponent compatibility shim for old GhostSystem

### DIFF
--- a/Content.Shared/Ghost/GhostComponent.cs
+++ b/Content.Shared/Ghost/GhostComponent.cs
@@ -89,6 +89,12 @@ public sealed partial class GhostComponent : Component
     public bool CanReturnToBody;
 
     /// <summary>
+    /// Backward-compatible alias for older server code paths that still gate admin-only visibility on ghosts.
+    /// </summary>
+    [DataField]
+    public bool CanSeeAdminVisibility;
+
+    /// <summary>
     /// Ghost color
     /// </summary>
     /// <remarks>Used to allow admins to change ghost colors. Should be removed if the capability to edit existing sprite colors is ever added back.</remarks>


### PR DESCRIPTION
Adds back a compatibility property on GhostComponent so older GhostSystem code paths that still reference CanSeeAdminVisibility compile without any changes to Content.Server/Ghost/GhostSystem.cs.

What changed:
- added a minimal CanSeeAdminVisibility property to GhostComponent
- left Content.Server/Ghost/GhostSystem.cs untouched

Why:
- CI was compiling a GhostSystem variant that still expects this property
- this keeps the server file unchanged while removing the compile error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Улучшения**
  * Добавлена поддержка обратной совместимости для старых версий серверов при определении видимости элементов только для администраторов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->