### PR TITLE
fix: disables firing from CryogenicSleepUnit

### DIFF
--- a/Resources/Prototypes/Entities/Structures/cryogenic_sleep_unit.yml
+++ b/Resources/Prototypes/Entities/Structures/cryogenic_sleep_unit.yml
@@ -35,6 +35,9 @@
         density: 190
         mask:
         - TableMask
+        layer:
+        - BulletImpassable
+  - type: RequireProjectileTarget
   - type: DragInsertContainer
     containerId: storage
     entryDelay: 2


### PR DESCRIPTION
## О ПР`е
Тип: fix
Изменения: Отключение возможности вести стрельбу из криогенной капсулы



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Исправления
* Криогенная капсула теперь блокирует прохождение снарядов. Обновлена модель взаимодействия конструкции с боевыми снарядами. Объект больше не является проницаемым для боеприпасов. Механика поведения криогенной капсулы пересмотрена для корректного отображения её защитных свойств при взаимодействии с боевыми снарядами в игровых сценариях и боевых ситуациях.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->