### PR TITLE
Рефатор подключения СМ, консоль теперь сообщает о состоянии СМ, чистка 

### DIFF
--- a/Content.Server/Imperial/Power/Components/SupermatterConsoleComponent.cs
+++ b/Content.Server/Imperial/Power/Components/SupermatterConsoleComponent.cs
@@ -14,6 +14,12 @@ public sealed partial class SupermatterConsoleComponent : Component
     public EntityUid? ConnectedSupermatter;
 
     /// <summary>
+    /// Максимальный радиус подключения к суперматерии
+    /// </summary>
+    [DataField]
+    public float MaxRange = 15f;
+
+    /// <summary>
     /// Имя порта для связи
     /// </summary>
     [DataField]

--- a/Content.Server/Imperial/Power/Components/SupermatterEventComponent.cs
+++ b/Content.Server/Imperial/Power/Components/SupermatterEventComponent.cs
@@ -77,17 +77,6 @@ public sealed partial class SupermatterEventComponent : Component
     public TimeSpan? PlasmaTickAccumulator = null;
 
     /// <summary>
-    /// Радио каналы для оповещений о событиях.
-    /// </summary>
-    [DataField]
-    public ProtoId<RadioChannelPrototype>[] RadioChannels = ["Engineering"];
-
-    /// <summary>
-    /// Время жизни кэша консоли (в секундах).
-    /// </summary>
-    public readonly TimeSpan ConsoleCacheLifetime = TimeSpan.FromSeconds(10);
-
-    /// <summary>
     /// Длительность события None (в секундах).
     /// </summary>
     [DataField]
@@ -187,7 +176,6 @@ public sealed partial class SupermatterEventComponent : Component
     [DataField]
     public float DefaultRadiationIntensity = Random.Shared.NextFloat(4, 5);
 
-    public TimeSpan LastConsoleCacheUpdate = TimeSpan.Zero;
     public TimeSpan LastEventEndTimeUpdate = TimeSpan.Zero;
     public TimeSpan LastNextEventTimerUpdate = TimeSpan.Zero;
     public TimeSpan LastLightningCooldownUpdate = TimeSpan.Zero;

--- a/Content.Server/Imperial/Power/EntitySystems/SupermatterConsoleSystem.cs
+++ b/Content.Server/Imperial/Power/EntitySystems/SupermatterConsoleSystem.cs
@@ -1,13 +1,16 @@
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.DeviceLinking.Systems;
 using Content.Server.Imperial.Power.Components;
-using Content.Shared.DeviceLinking;
 using Content.Shared.DeviceLinking.Events;
 using Content.Shared.Imperial.Power;
 using Content.Shared.Imperial.Power.Components;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
 using System.Linq;
+using Content.Server.Chat.Systems;
+using Content.Server.Radio.EntitySystems;
+using Content.Shared.Chat;
+using Content.Shared.DeviceLinking;
 using Content.Shared.Imperial.Power.Events;
 using Robust.Shared.Timing;
 
@@ -16,11 +19,12 @@ namespace Content.Server.Imperial.Power.EntitySystems;
 public sealed class SupermatterConsoleSystem : EntitySystem
 {
     [Dependency] private readonly AtmosphereSystem _atmosSystem = null!;
-    [Dependency] private readonly SharedAudioSystem _audioSystem = null!;
-    [Dependency] private readonly SharedTransformSystem _transformSystem = null!;
-    [Dependency] private readonly UserInterfaceSystem _uiSystem = null!;
+    [Dependency] private readonly ChatSystem _chatSystem = null!;
     [Dependency] private readonly DeviceLinkSystem _signalSystem = null!;
     [Dependency] private readonly IGameTiming _timing = null!;
+    [Dependency] private readonly RadioSystem _radioSystem = null!;
+    [Dependency] private readonly SharedAudioSystem _audioSystem = null!;
+    [Dependency] private readonly UserInterfaceSystem _uiSystem = null!;
 
     public override void Initialize()
     {
@@ -34,14 +38,9 @@ public sealed class SupermatterConsoleSystem : EntitySystem
         SubscribeLocalEvent<SupermatterConsoleComponent, PortDisconnectedEvent>(OnPortDisconnected);
 
         SubscribeLocalEvent<SupermatterConsoleComponent, BoundUIOpenedEvent>(OnUiOpened);
-    }
 
-    private static void OnUiOpened(Entity<SupermatterConsoleComponent> entity, ref BoundUIOpenedEvent args)
-    {
-        if (!args.UiKey.Equals(SupermatterConsoleUiKey.Key))
-            return;
-
-        entity.Comp.NextUiUpdate = TimeSpan.Zero;
+        SubscribeLocalEvent<SupermatterIntegrityComponent, SupermatterStartupEvent>(OnSupermatterStartup);
+        SubscribeLocalEvent<SupermatterIntegrityComponent, SupermatterSendRadioEvent>(OnSendRadioEvent);
     }
 
     private void OnInit(Entity<SupermatterConsoleComponent> entity, ref ComponentInit args)
@@ -86,24 +85,67 @@ public sealed class SupermatterConsoleSystem : EntitySystem
         UpdateUi(entity, true);
     }
 
-    private EntityUid? FindNearestSupermatter(EntityUid consoleUid)
+    private static void OnUiOpened(Entity<SupermatterConsoleComponent> entity, ref BoundUIOpenedEvent args)
     {
-        var transformCompConsole = Transform(consoleUid);
-        var mapId = transformCompConsole.MapID;
-        var pos = _transformSystem.GetMapCoordinates(transformCompConsole).Position;
+        if (!args.UiKey.Equals(SupermatterConsoleUiKey.Key))
+            return;
 
-        EntityUid? nearest = null;
-        var minDist = float.MaxValue;
+        entity.Comp.NextUiUpdate = TimeSpan.Zero;
+    }
 
-        var smEnumerator = EntityQueryEnumerator<SupermatterIntegrityComponent, TransformComponent>();
-        while (smEnumerator.MoveNext(out var smUid, out _, out var transComp))
+    private void OnSupermatterStartup(Entity<SupermatterIntegrityComponent> supermatter, ref SupermatterStartupEvent args)
+    {
+        var query = EntityQueryEnumerator<SupermatterConsoleComponent, TransformComponent>();
+        var smTrans = Transform(supermatter.Owner);
+
+        while (query.MoveNext(out var consoleUid, out var consoleComp, out var consoleTrans))
         {
-            if (transComp.MapID != mapId)
+            if (consoleComp.ConnectedSupermatter != null)
+                continue;
+            var maxRange = consoleComp.MaxRange;
+
+            if (!smTrans.Coordinates.TryDistance(EntityManager, consoleTrans.Coordinates, out var distance)
+                || distance > maxRange)
                 continue;
 
-            var smPos = _transformSystem.GetMapCoordinates(smUid).Position;
-            var dist = (smPos - pos).LengthSquared();
-            if (dist > minDist)
+            _signalSystem.LinkDefaults(null, supermatter.Owner, consoleUid);
+            consoleComp.ConnectedSupermatter = supermatter.Owner;
+        }
+    }
+
+    private void OnSendRadioEvent(Entity<SupermatterIntegrityComponent> entity, ref SupermatterSendRadioEvent args)
+    {
+        var query = EntityQueryEnumerator<SupermatterConsoleComponent>();
+        var radioSent = false;
+
+        while (query.MoveNext(out var consoleUid, out var consoleComp))
+        {
+            if (consoleComp.ConnectedSupermatter != entity)
+                continue;
+
+            _chatSystem.TrySendInGameICMessage(consoleUid, args.Message, InGameICChatType.Speak, ChatTransmitRange.Normal);
+
+            if (radioSent)
+                continue;
+
+            foreach (var channel in entity.Comp.RadioChannels)
+                _radioSystem.SendRadioMessage(consoleUid, args.Message, channel, consoleUid);
+
+            radioSent = true;
+        }
+    }
+
+    private EntityUid? FindNearestSupermatter(Entity<SupermatterConsoleComponent> console)
+    {
+        var pos = Transform(console).Coordinates;
+        EntityUid? nearest = null;
+        var minDist = console.Comp.MaxRange;
+
+        var smEnumerator = EntityQueryEnumerator<SupermatterIntegrityComponent, TransformComponent>();
+        while (smEnumerator.MoveNext(out var smUid, out _, out var smTrans))
+        {
+            if (!pos.TryDistance(EntityManager, smTrans.Coordinates, out var dist)
+                || dist > minDist)
                 continue;
 
             minDist = dist;
@@ -111,7 +153,7 @@ public sealed class SupermatterConsoleSystem : EntitySystem
         }
 
         if (nearest != null)
-            _signalSystem.LinkDefaults(null, nearest.Value, consoleUid);
+            _signalSystem.LinkDefaults(null, nearest.Value, console);
 
         return nearest;
     }

--- a/Content.Server/Imperial/Power/EntitySystems/SupermatterEventSystem.cs
+++ b/Content.Server/Imperial/Power/EntitySystems/SupermatterEventSystem.cs
@@ -1,17 +1,14 @@
 using Content.Server.Atmos.EntitySystems;
-using Content.Server.Chat.Systems;
 using Content.Server.Imperial.Power.Components;
 using Content.Server.Imperial.Power.EntitySystems.Events;
 using Content.Server.Lightning;
 using Content.Server.NukeOps;
 using Content.Server.Radiation.Systems;
-using Content.Server.Radio.EntitySystems;
-using Content.Shared.Chat;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Imperial.Power.Components;
+using Content.Shared.Imperial.Power.Events;
 using Content.Shared.NukeOps;
 using Content.Shared.Radiation.Components;
-using Robust.Server.GameObjects;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -24,14 +21,8 @@ public sealed class SupermatterEventSystem : EntitySystem
     [Dependency] public readonly IGameTiming GameTiming = null!;
     [Dependency] public readonly LightningSystem LightningSystem = null!;
     [Dependency] public readonly SharedMapSystem MapSystem = null!;
-    [Dependency] private readonly ChatSystem _chatSystem = null!;
     [Dependency] private readonly IRobustRandom _random = null!;
-    [Dependency] private readonly RadioSystem _radio = null!;
-    [Dependency] private readonly TransformSystem _transformSystem = null!;
     [Dependency] private readonly RadiationSystem _radiationSystem = null!;
-
-    // Кеш ближайших консолей для кристаллов
-    private readonly Dictionary<EntityUid, (EntityUid console, float time)> _nearestConsoleCache = new();
 
     public override void Initialize()
     {
@@ -44,7 +35,6 @@ public sealed class SupermatterEventSystem : EntitySystem
     private void OnInit(Entity<SupermatterEventComponent> entity, ref ComponentInit args)
     {
         var currentTime = GameTiming.CurTime;
-        entity.Comp.LastConsoleCacheUpdate = currentTime;
         entity.Comp.LastEventEndTimeUpdate = currentTime;
         entity.Comp.LastNextEventTimerUpdate = currentTime;
         entity.Comp.LastLightningCooldownUpdate = currentTime;
@@ -97,7 +87,6 @@ public sealed class SupermatterEventSystem : EntitySystem
     {
         var currentTime = GameTiming.CurTime;
 
-        UpdateConsoleCache(entity, currentTime);
         UpdateEventEndTimer(entity.Comp1, currentTime);
 
         if (!entity.Comp2.Activated)
@@ -110,16 +99,6 @@ public sealed class SupermatterEventSystem : EntitySystem
 
         TryStartNewEvent(entity);
         ProcessActiveEvent(entity, currentTime);
-    }
-
-
-    private void UpdateConsoleCache(Entity<SupermatterEventComponent> entity, TimeSpan currentTime)
-    {
-        if (currentTime - entity.Comp.LastConsoleCacheUpdate < entity.Comp.ConsoleCacheLifetime)
-            return;
-
-        _nearestConsoleCache.Remove(entity);
-        entity.Comp.LastConsoleCacheUpdate = currentTime;
     }
 
     private static void UpdateEventEndTimer(SupermatterEventComponent comp, TimeSpan currentTime)
@@ -167,9 +146,7 @@ public sealed class SupermatterEventSystem : EntitySystem
             return;
 
         if (comp.CurrentEvent == SupermatterEventComponent.SupermatterEventType.Radiation)
-        {
             _radiationSystem.SetIntensity(entity.Owner, comp.DefaultRadiationIntensity);
-        }
 
         var randomEvtIndex = _random.Next(0, comp.AllowedEventTypes.Count);
         var randomEvtType = comp.AllowedEventTypes[randomEvtIndex];
@@ -225,50 +202,10 @@ public sealed class SupermatterEventSystem : EntitySystem
         }
     }
 
-
-
     private void AnnounceFromSupermatterConsole(EntityUid crystal, string message)
     {
-        var timeNow = (float)GameTiming.CurTime.TotalSeconds;
-        EntityUid? nearestConsole = null;
-
-        var mapCoordinates = _transformSystem.GetMapCoordinates(crystal);
-        var crystalPos = mapCoordinates.Position;
-        var mapId = mapCoordinates.MapId;
-
-        if (!TryComp<SupermatterEventComponent>(crystal, out var eventComp))
-            return;
-
-        if (_nearestConsoleCache.TryGetValue(crystal, out var cached) && TimeSpan.FromSeconds(timeNow - cached.time) < eventComp.ConsoleCacheLifetime)
-        {
-            nearestConsole = cached.console;
-        }
-        else
-        {
-            var minDist = float.MaxValue;
-            var enumerator = EntityQueryEnumerator<SupermatterConsoleComponent, TransformComponent>();
-            while (enumerator.MoveNext(out var consoleUid, out _, out var transformComp))
-            {
-                if (transformComp.MapID != mapId)
-                    continue;
-                var consolePos = _transformSystem.GetMapCoordinates(consoleUid).Position;
-                var dist = (consolePos - crystalPos).LengthSquared();
-
-                if (dist > minDist)
-                    continue;
-
-                minDist = dist;
-                nearestConsole = consoleUid;
-            }
-            if (nearestConsole != null)
-                _nearestConsoleCache[crystal] = (nearestConsole.Value, timeNow);
-        }
-
-        foreach (var channel in eventComp.RadioChannels)
-        {
-            _chatSystem.TrySendInGameICMessage(nearestConsole ?? crystal, message, InGameICChatType.Speak, ChatTransmitRange.Normal);
-            _radio.SendRadioMessage(nearestConsole ?? crystal, message, channel, nearestConsole ?? crystal);
-        }
+        var ev = new SupermatterSendRadioEvent(message);
+        RaiseLocalEvent(crystal, ref ev);
     }
 
     public void SetRadiation(EntityUid uid, float intensity)

--- a/Content.Server/Imperial/Power/EntitySystems/SupermatterGasSystem.cs
+++ b/Content.Server/Imperial/Power/EntitySystems/SupermatterGasSystem.cs
@@ -57,7 +57,6 @@ public sealed class SupermatterGasSystem : EntitySystem
 
     private void OnAtmosExposedUpdate(EntityUid uid, SupermatterGasComponent component, ref AtmosExposedUpdateEvent args)
     {
-        component.CachedGasMixture = args.GasMixture;
         if (!TryComp(uid, out SupermatterIntegrityComponent? integrity))
             return;
 

--- a/Content.Server/Imperial/Power/EntitySystems/SupermatterIntegritySystem.cs
+++ b/Content.Server/Imperial/Power/EntitySystems/SupermatterIntegritySystem.cs
@@ -27,21 +27,9 @@ public sealed class SupermatterIntegritySystem : EntitySystem
     [Dependency] private readonly SharedAmbientSoundSystem _ambientSound = null!;
     [Dependency] private readonly SharedPointLightSystem _lightSystem = null!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = null!;
-    [Dependency] private readonly RadioSystem _radioSystem = null!;
     [Dependency] private readonly StationSystem _stationSystem = null!;
     [Dependency] private readonly IGameTiming _gameTiming = null!;
     [Dependency] private readonly RadiationSystem _radiationSystem = null!;
-
-    public override void Initialize()
-    {
-        base.Initialize();
-        SubscribeLocalEvent<SupermatterIntegrityComponent, SupermatterSendRadioEvent>(OnSupermatterSendRadioEvent);
-    }
-
-    private void OnSupermatterSendRadioEvent(Entity<SupermatterIntegrityComponent> ent, ref SupermatterSendRadioEvent args)
-    {
-        SendSupermatterRadio(ent, args.Message);
-    }
 
     public override void Update(float frameTime)
     {
@@ -108,7 +96,8 @@ public sealed class SupermatterIntegritySystem : EntitySystem
                 continue;
 
             var integrityWarning = Loc.GetString(level.Warning);
-            SendSupermatterRadio(entity, integrityWarning);
+            var ev = new SupermatterSendRadioEvent(integrityWarning);
+            RaiseLocalEvent(entity, ref ev);
 
             // Если мы достигли уровня с порогом <= 10% — выставляем код тревоги для станции и объявление.
             // Раньше использовался MinBy по всем порогам (что возвращало 0) и из-за этого код не ставился.
@@ -205,12 +194,5 @@ public sealed class SupermatterIntegritySystem : EntitySystem
         {
             entity.Comp.NextDamageTick = TimeSpan.Zero;
         }
-    }
-
-    // Отправка сообщения в общую рацию от имени суперматерии
-    private void SendSupermatterRadio(Entity<SupermatterIntegrityComponent> entity, string message)
-    {
-        _chatSystem.TrySendInGameICMessage(entity, message, InGameICChatType.Speak, ChatTransmitRange.Normal);
-        _radioSystem.SendRadioMessage(entity, message, entity.Comp.RadioChannel, entity);
     }
 }

--- a/Content.Server/Imperial/Power/EntitySystems/SupermatterTouchSystem.cs
+++ b/Content.Server/Imperial/Power/EntitySystems/SupermatterTouchSystem.cs
@@ -1,13 +1,12 @@
 using Content.Server.Effects;
 using Content.Server.Imperial.Power.Components;
 using Content.Shared.Mobs.Components;
-using Content.Shared.Atmos;
 using Content.Shared.Imperial.Power.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Player;
-using Content.Server.Atmos.EntitySystems;
 using Content.Server.Imperial.Power.EntitySystems.Events;
+using Content.Shared.Damage.Components;
 
 namespace Content.Server.Imperial.Power.EntitySystems;
 
@@ -25,7 +24,7 @@ public sealed class SupermatterTouchSystem : EntitySystem
     private void OnStartCollide(Entity<SupermatterTouchComponent> supermatter, ref StartCollideEvent args)
     {
         var other = args.OtherEntity;
-        if (!HasComp<MobStateComponent>(other))
+        if (!HasComp<MobStateComponent>(other) || HasComp<GodmodeComponent>(other))
             return;
 
         var touchEvent = new SupermatterTouchedEvent();
@@ -34,13 +33,11 @@ public sealed class SupermatterTouchSystem : EntitySystem
             return;
 
         var transformComp = Transform(other);
-
-        Entity<TransformComponent> entity = new(other, transformComp);
-        GibCollidedEntity(supermatter, entity);
+        GibCollidedEntity(supermatter, (other, transformComp));
 
     }
 
-    private void OnTouched(Entity<SupermatterGasComponent> supermatter, ref SupermatterTouchedEvent args)
+    private static void OnTouched(Entity<SupermatterGasComponent> supermatter, ref SupermatterTouchedEvent args)
     {
         if (args.Cancelled)
             return;

--- a/Content.Shared/Imperial/Power/Components/SupermatterGasComponent.cs
+++ b/Content.Shared/Imperial/Power/Components/SupermatterGasComponent.cs
@@ -1,4 +1,3 @@
-using Content.Shared.Atmos;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared.Imperial.Power.Components;

--- a/Content.Shared/Imperial/Power/Components/SupermatterGasComponent.cs
+++ b/Content.Shared/Imperial/Power/Components/SupermatterGasComponent.cs
@@ -42,10 +42,5 @@ public sealed partial class SupermatterGasComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan LastAtmosUpdate;
-
-    public bool WasShutdownByAntiNoblium;
-
-    [ViewVariables(VVAccess.ReadOnly)]
-    public GasMixture? CachedGasMixture;
 }
 

--- a/Content.Shared/Imperial/Power/Components/SupermatterIntegrityComponent.cs
+++ b/Content.Shared/Imperial/Power/Components/SupermatterIntegrityComponent.cs
@@ -47,7 +47,7 @@ public sealed partial class SupermatterIntegrityComponent : Component
     public float CatastropheThreshold;
 
     [DataField]
-    public ProtoId<RadioChannelPrototype> RadioChannel = "Engineering";
+    public ProtoId<RadioChannelPrototype>[] RadioChannels = ["Engineering"];
 
     [ViewVariables(VVAccess.ReadWrite)]
     public bool CatastropheActive;

--- a/Content.Shared/Imperial/Power/Events/SupermatterStartupEvent.cs
+++ b/Content.Shared/Imperial/Power/Events/SupermatterStartupEvent.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared.Imperial.Power.Events;
+
+[ByRefEvent]
+public readonly record struct SupermatterStartupEvent();

--- a/Content.Shared/Imperial/Power/GasReactions/ISupermatterGasReaction.cs
+++ b/Content.Shared/Imperial/Power/GasReactions/ISupermatterGasReaction.cs
@@ -1,6 +1,5 @@
 using Content.Shared.Atmos;
 using Content.Shared.Imperial.Power.Components;
-using Robust.Shared.GameObjects;
 
 namespace Content.Shared.Imperial.Power.GasReactions;
 

--- a/Content.Shared/Imperial/Power/GasReactions/Reactions/SupermatterAntiNobliumShutdownReaction.cs
+++ b/Content.Shared/Imperial/Power/GasReactions/Reactions/SupermatterAntiNobliumShutdownReaction.cs
@@ -1,7 +1,5 @@
 using Content.Shared.Atmos;
 using Content.Shared.Imperial.Power.Components;
-using Content.Shared.Imperial.Power.GasReactions;
-using Robust.Shared.GameObjects;
 
 namespace Content.Shared.Imperial.Power.GasReactions.Reactions;
 
@@ -24,7 +22,6 @@ public sealed partial class SupermatterAntiNobliumShutdownReaction : ISupermatte
             return;
 
         integrity.Activated = false;
-        gasComp.WasShutdownByAntiNoblium = true;
     }
 }
 

--- a/Content.Shared/Imperial/Power/GasReactions/Reactions/SupermatterDisableTouchReaction.cs
+++ b/Content.Shared/Imperial/Power/GasReactions/Reactions/SupermatterDisableTouchReaction.cs
@@ -1,7 +1,5 @@
 using Content.Shared.Atmos;
 using Content.Shared.Imperial.Power.Components;
-using Content.Shared.Imperial.Power.GasReactions;
-using Robust.Shared.GameObjects;
 
 namespace Content.Shared.Imperial.Power.GasReactions.Reactions;
 

--- a/Content.Shared/Imperial/Power/GasReactions/Reactions/SupermatterEventSpeedMultiplierReaction.cs
+++ b/Content.Shared/Imperial/Power/GasReactions/Reactions/SupermatterEventSpeedMultiplierReaction.cs
@@ -1,7 +1,5 @@
 using Content.Shared.Atmos;
 using Content.Shared.Imperial.Power.Components;
-using Content.Shared.Imperial.Power.GasReactions;
-using Robust.Shared.GameObjects;
 
 namespace Content.Shared.Imperial.Power.GasReactions.Reactions;
 

--- a/Content.Shared/Imperial/Power/GasReactions/Reactions/SupermatterIntegrityRegenReaction.cs
+++ b/Content.Shared/Imperial/Power/GasReactions/Reactions/SupermatterIntegrityRegenReaction.cs
@@ -1,7 +1,5 @@
 using Content.Shared.Atmos;
 using Content.Shared.Imperial.Power.Components;
-using Content.Shared.Imperial.Power.GasReactions;
-using Robust.Shared.GameObjects;
 
 namespace Content.Shared.Imperial.Power.GasReactions.Reactions;
 

--- a/Content.Shared/Imperial/Power/GasReactions/Reactions/SupermatterLightningMultiplierReaction.cs
+++ b/Content.Shared/Imperial/Power/GasReactions/Reactions/SupermatterLightningMultiplierReaction.cs
@@ -1,7 +1,5 @@
 using Content.Shared.Atmos;
 using Content.Shared.Imperial.Power.Components;
-using Content.Shared.Imperial.Power.GasReactions;
-using Robust.Shared.GameObjects;
 
 namespace Content.Shared.Imperial.Power.GasReactions.Reactions;
 

--- a/Content.Shared/Imperial/Power/GasReactions/Reactions/SupermatterRadiationMultiplierReaction.cs
+++ b/Content.Shared/Imperial/Power/GasReactions/Reactions/SupermatterRadiationMultiplierReaction.cs
@@ -1,7 +1,5 @@
 using Content.Shared.Atmos;
 using Content.Shared.Imperial.Power.Components;
-using Content.Shared.Imperial.Power.GasReactions;
-using Robust.Shared.GameObjects;
 
 namespace Content.Shared.Imperial.Power.GasReactions.Reactions;
 

--- a/Content.Shared/Imperial/Power/Systems/SupermatterIntegritySystem.cs
+++ b/Content.Shared/Imperial/Power/Systems/SupermatterIntegritySystem.cs
@@ -20,9 +20,16 @@ public sealed class SupermatterIntegritySystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<SupermatterIntegrityComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<SupermatterIntegrityComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<SupermatterIntegrityComponent, AfterInteractUsingEvent>(OnInteractUsing);
         SubscribeLocalEvent<SupermatterIntegrityComponent, SupermatterShutdownDoAfterEvent>(OnDoAfter);
         SubscribeLocalEvent<SupermatterIntegrityComponent, StartCollideEvent>(OnStartCollide);
+    }
+
+    private void OnInit(Entity<SupermatterIntegrityComponent> ent, ref ComponentInit args)
+    {
+        var ev = new SupermatterStartupEvent();
+        RaiseLocalEvent(ent, ref ev);
     }
 
     private void OnStartCollide(Entity<SupermatterIntegrityComponent> entity, ref StartCollideEvent args)

--- a/Resources/Prototypes/Imperial/Entities/Structures/Power/Generation/SuperMatter/monitor_console.yml
+++ b/Resources/Prototypes/Imperial/Entities/Structures/Power/Generation/SuperMatter/monitor_console.yml
@@ -1,47 +1,42 @@
 - type: entity
-  id: SupermatterMonitorConsole
   name: supermatter monitor console
+  parent: BaseWallmountMachine
+  id: SupermatterMonitorConsole
   description: A console that displays the exact integrity of the nearest supermatter crystal.
-  placement:
-    mode: SnapgridCenter
   components:
-    - type: Transform
-      anchored: true
-      noRot: true
-    - type: Physics
-    - type: Fixtures
-      fixtures:
-        fix1:
-          shape:
-            !type:PhysShapeAabb
-            bounds: "-0.5,-0.5,0.5,0.5"
-          mask:
-            - MidImpassable
-            - HighImpassable
-            - LowImpassable
-          layer:
-            - MidImpassable
-            - HighImpassable
-            - BulletImpassable
-            - InteractImpassable
-    - type: Clickable
-    - type: InteractionOutline
-    - type: Sprite
-      sprite: Imperial/ussp/computers.rsi
-      state: comm_monitor
-    - type: Icon
-      sprite: Imperial/ussp/computers.rsi
-      state: comm_monitor
-    - type: Appearance
-    - type: PowerConsumer
-      drawRate: 10
-      voltage: 120
-    - type: SupermatterConsole
-    - type: DeviceLinkSink
-    - type: UserInterface
-      interfaces:
-        enum.SupermatterConsoleUiKey.Key:
-          type: SupermatterConsoleBoundUserInterface
-    - type: ActivatableUI
-      requiresComplex: true
-      key: enum.SupermatterConsoleUiKey.Key
+  - type: ActivatableUI
+    requiresComplex: true
+    key: enum.SupermatterConsoleUiKey.Key
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 75
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
+          params:
+            volume: -4
+  - type: DeviceLinkSink
+  - type: Icon
+    sprite: Imperial/ussp/computers.rsi
+    state: comm_monitor
+  - type: PowerConsumer
+    drawRate: 10
+    voltage: 120
+  - type: Speech
+    speechSounds: Pai
+  - type: Sprite
+    sprite: Imperial/ussp/computers.rsi
+    state: comm_monitor
+  - type: SupermatterConsole
+  - type: UserInterface
+    interfaces:
+      enum.SupermatterConsoleUiKey.Key:
+        type: SupermatterConsoleBoundUserInterface


### PR DESCRIPTION
## О ПР`е
<!-- Эта информация попадет в чейнджлог, пожалуйста, заполните ее -->

Тип: tweak
Изменения: Теперь консоль сообщает о состоянии СМ, а не сам кристалл.

Тип: fix
Изменения: На карте Box суперматерия теперь успешно подключается к консоли.

<!--
    Пример правильного заполнения:

    Тип: tweak
    Изменения: Урон от туллбокса был увеличен в два раза
-->

## Технические детали

Я думаю всё ясно

## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->

*Нет*
